### PR TITLE
Add a custom Context with align_{} params and a BaseCommand that uses it

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,26 @@ v0.8.0 (in development)
 
 - Cloup license changed from MIT to 3-clause BSD, the one used by Click.
 
+** Compatible changes
+
+- Added a custom `Context` class, having the following additional parameters:
+
+  * ``align_option_groups = True``,
+  * ``align_sections = True``.
+
+  The corresponding arguments in ``OptionGroupMixin`` and ``SectionMixin`` were
+  set to ``None``. By setting them, you can override the context value.
+
+- Changed the class hierarchy:
+
+  * added a ``BaseCommand``, extending ``click.Command`` and using the custom
+    ``Context`` by default. This class also "backports" the Click 8.0 class
+    attribute ``context_class``.
+
+  * ``cloup.Command`` and `cloup.MultiCommand` extends ``cloup.BaseCommand``
+
+  * ``cloup.Group`` now extends ``cloup.MultiCommand``.
+
 
 v0.7.0 (2021-03-24)
 ===================

--- a/cloup/__init__.py
+++ b/cloup/__init__.py
@@ -8,6 +8,7 @@ __version__ = _version.version
 __version_tuple__ = _version.version_tuple
 
 # flake8: noqa F401
+from ._context import Context
 from ._option_groups import (
     GroupedOption, OptionGroup, OptionGroupMixin, option, option_group
 )

--- a/cloup/_context.py
+++ b/cloup/_context.py
@@ -1,0 +1,15 @@
+import click
+
+
+class Context(click.Context):
+    """A Context that adds a ``formatter_factory`` instance argument."""
+
+    def __init__(
+        self, *args,
+        align_option_groups: bool = True,
+        align_sections: bool = True,
+        **ctx_kwargs,
+    ):
+        super().__init__(*args, **ctx_kwargs)
+        self.align_option_groups = align_option_groups
+        self.align_sections = align_sections

--- a/cloup/_sections.py
+++ b/cloup/_sections.py
@@ -3,6 +3,8 @@ from typing import Dict, Iterable, List, Optional, Sequence, Tuple, Type, TypeVa
 
 import click
 
+from cloup._util import coalesce
+
 CommandType = TypeVar('CommandType', bound=Type[click.Command])
 Subcommands = Union[Iterable[click.Command], Dict[str, click.Command]]
 
@@ -92,7 +94,7 @@ class SectionMixin:
         self, *args,
         commands: Optional[Dict[str, click.Command]] = None,
         sections: Iterable[Section] = (),
-        align_sections: bool = True,
+        align_sections: Optional[bool] = None,
         **kwargs,
     ):
         """
@@ -155,10 +157,19 @@ class SectionMixin:
             section_list.append(default_section)
         return section_list
 
+    def must_align_sections(
+        self, ctx: Optional[click.Context], default: bool = True
+    ) -> bool:
+        return coalesce(
+            self.align_sections,
+            getattr(ctx, 'align_sections', None),
+            default,
+        )  # type: ignore
+
     def format_commands(self, ctx: click.Context, formatter: click.HelpFormatter):
         section_list = self.list_sections(ctx)
         command_name_col_width = None
-        if self.align_sections:
+        if self.must_align_sections(ctx):
             command_name_col_width = max(len(name)
                                          for section in section_list
                                          for name in section.commands)

--- a/cloup/_util.py
+++ b/cloup/_util.py
@@ -1,5 +1,8 @@
 """Generic utilities."""
-from typing import Iterable, List
+from typing import Iterable, List, Optional, TypeVar
+
+
+T = TypeVar('T')
 
 
 def class_name(obj):
@@ -61,3 +64,12 @@ def pluralize(
     if count == 1 and one:
         return one
     return many.format(count=count)
+
+
+def coalesce(*values: Optional[T], default=None) -> Optional[T]:
+    """Returns the first value that is not None (or ``default`` if no such value exists).
+    Inspired by the homonym SQL function."""
+    for val in values:
+        if val is not None:
+            return val
+    return default

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 from click.testing import CliRunner
 from pytest import fixture
 
@@ -7,7 +9,9 @@ from tests.example_group import make_example_group
 
 @fixture()
 def runner():
-    return CliRunner()
+    runner = CliRunner()
+    runner.invoke = partial(runner.invoke, catch_exceptions=True)
+    return runner
 
 
 @fixture(scope='session')


### PR DESCRIPTION
- Added a custom `Context` class, having the following additional parameters:

  * ``align_option_groups = True``,
  * ``align_sections = True``.

  The corresponding arguments in ``OptionGroupMixin`` and ``SectionMixin`` were
  set to ``None``. By setting them, you can override the context value.

- Changed the class hierarchy:

  * added a ``BaseCommand``, extending ``click.Command`` and using the custom
    ``Context`` by default. This class also "backports" the Click 8.0 class
    attribute ``context_class``.

  * ``cloup.Command`` and `cloup.MultiCommand` extends ``cloup.BaseCommand``

  * ``cloup.Group`` now extends ``cloup.MultiCommand``.