### PR TITLE
Replace Constraint.__check_consistency and related methods with a Context setting

### DIFF
--- a/cloup/_context.py
+++ b/cloup/_context.py
@@ -29,6 +29,9 @@ class Context(click.Context):
 
     Look up :class:`click.Context` for the list of all arguments.
 
+    .. versionchanged:: 0.9.0
+        Added parameter ``check_constraints_consistency``.
+
     .. versionadded:: 0.8.0
 
     :param ctx_args:
@@ -46,6 +49,9 @@ class Context(click.Context):
     :param show_constraints:
         whether to include a "Constraint" section in the command help (if at
         least one constraint is defined).
+    :param check_constraints_consistency:
+        enable additional checks for constraints which detects mistakes of the
+        developer (see :meth:`cloup.Constraint.check_consistency`).
     :param formatter_settings:
         keyword arguments forwarded to :class:`HelpFormatter` in ``make_formatter``.
         This args are merged with those of the (eventual) parent context and then
@@ -60,6 +66,7 @@ class Context(click.Context):
         align_option_groups: Optional[bool] = None,
         align_sections: Optional[bool] = None,
         show_constraints: Optional[bool] = None,
+        check_constraints_consistency: bool = True,
         formatter_settings: Dict[str, Any] = {},
         **ctx_kwargs,
     ):
@@ -76,6 +83,7 @@ class Context(click.Context):
             show_constraints,
             getattr(self.parent, 'show_constraints', None),
         )
+        self.check_constraints_consistency = check_constraints_consistency
 
         if cloup.warnings.formatter_settings_conflict:
             _warn_if_formatter_settings_conflict(
@@ -121,6 +129,7 @@ class Context(click.Context):
         align_option_groups: Optional[bool] = None,
         align_sections: Optional[bool] = None,
         show_constraints: Optional[bool] = None,
+        check_constraints_consistency: Optional[bool] = None,
         formatter_settings: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Utility method for creating a ``context_settings`` dictionary.
@@ -184,6 +193,9 @@ class Context(click.Context):
         :param show_constraints:
             whether to include a "Constraint" section in the command help (if at
             least one constraint is defined).
+        :param check_constraints_consistency:
+            enable additional checks for constraints which detects mistakes of the
+            developer (see :meth:`cloup.Constraint.check_consistency`).
         :param formatter_settings:
             keyword arguments forwarded to :class:`HelpFormatter` in ``make_formatter``.
             This args are merged with those of the (eventual) parent context and then

--- a/cloup/constraints/_support.py
+++ b/cloup/constraints/_support.py
@@ -98,7 +98,7 @@ class ConstraintMixin:
     def parse_args(self, ctx, args):
         all_constraints = self._optgroup_constraints + self._extra_constraints
         # Check parameter groups' consistency *before* parsing
-        if Constraint.must_check_consistency():
+        if Constraint.must_check_consistency(ctx):
             for constr in all_constraints:
                 constr.check_consistency()
         super().parse_args(ctx, args)

--- a/docs/pages/constraints.rst
+++ b/docs/pages/constraints.rst
@@ -399,21 +399,28 @@ micro-optimization likely to be completely irrelevant in practice.
 
 Current consistency checks should not have any relevant impact on performance,
 so they are enabled by default. Nonetheless, they are completely useless in
-production, so I added the possibility to turn them off (globally) using the
-class method :meth:`Constraint.toggle_consistency_checks`. Just because I could.
+production, so I added the possibility to turn them off (globally) passing
+``check_constraints_consistency=False`` as part of your ``context_settings``.
+Just because I could.
 
-To disable them only in production, you should set an environment variable in the
-system you use for development, say ``PYTHON_ENV="dev"``; then you can put the
-following code in the entry-point of your program:
+To disable them only in production, you should set an environment variable in
+your development machine, say ``PYTHON_ENV="dev"``; then you can put the
+following code at the entry-point of your program:
 
 .. code-block:: python
 
     import os
+    from cloup import Context
 
-    # Enable consistency checks only if PYTHON_ENV is defined and equal to 'dev'
-    Constraint.toggle_consistency_checks(
-        os.getenv('PYTHON_ENV') == 'dev'
+    SETTINGS = Context.setting(
+        check_constraints_consistency=(os.getenv('PYTHON_ENV') == 'dev')
+        # ... other settings ...
     )
+
+    @group(context_settings=SETTINGS)
+    # ...
+    def main(...):
+        ...
 
 Have I already mentioned that this is probably not worth the effort?
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -2,10 +2,11 @@ from contextlib import contextmanager
 from typing import Iterable, List
 from unittest.mock import Mock
 
+import click
 import pytest
-from click import Command, Context, Option
 
 import cloup
+from cloup import Context
 
 
 def noop(*args, **kwargs):
@@ -13,45 +14,47 @@ def noop(*args, **kwargs):
 
 
 def int_opt(*args, **kwargs):
-    return Option(*args, type=int, **kwargs)
+    return click.Option(*args, type=int, **kwargs)
 
 
 def bool_opt(*args, **kwargs):
-    return Option(*args, type=bool, **kwargs)
+    return click.Option(*args, type=bool, **kwargs)
 
 
 def flag_opt(*args, **kwargs):
-    return Option(*args, is_flag=True, **kwargs)
+    return click.Option(*args, is_flag=True, **kwargs)
 
 
 def multi_opt(*args, **kwargs):
-    return Option(*args, multiple=True, **kwargs)
+    return click.Option(*args, multiple=True, **kwargs)
 
 
 def tuple_opt(*args, **kwargs):
-    return Option(*args, nargs=3, **kwargs)
+    return click.Option(*args, nargs=3, **kwargs)
 
 
 def parametrize(argnames, *argvalues, **kwargs):
     return pytest.mark.parametrize(argnames, argvalues, **kwargs)
 
 
-def make_context(cmd: Command, shell: str) -> Context:
+def make_context(cmd: click.Command, shell: str) -> click.Context:
     args = shell.split()
     return cmd.make_context(cmd.name, args)
 
 
 def make_fake_context(
-    params: Iterable[str],
+    params: Iterable[click.Parameter],
     command_cls=cloup.Command,
+    cls=Context,
+    **ctx_kwargs
 ) -> Context:
     """Creates a simple instance of Command with the specified parameters,
     then create a fake context without actually invoking the command."""
-    return Context(command_cls('fake', params=params, callback=noop))
+    return cls(command_cls('fake', params=params, callback=noop), **ctx_kwargs)
 
 
-def make_options(names: Iterable[str], **common_kwargs) -> List[Option]:
-    return [Option([f'--{name}'], **common_kwargs) for name in names]
+def make_options(names: Iterable[str], **common_kwargs) -> List[click.Option]:
+    return [click.Option([f'--{name}'], **common_kwargs) for name in names]
 
 
 def should_raise(expected_exception, *, when, **kwargs):


### PR DESCRIPTION
Closes #33.

The context setting was called `check_constraints_consistency`.

## Breaking changes
- removed `toggle_consistency_checks`
- removed `consistency_checks_toggled`
- `must_check_consistency` is now a static method taking
  an argument of type `click.Context`