### PR TITLE
Redesign `row_sep`

### DIFF
--- a/cloup/__init__.py
+++ b/cloup/__init__.py
@@ -24,7 +24,10 @@ from .styling import (
     Style,
     Color,
 )
-from .formatting import HelpFormatter
+from .formatting import (
+    HelpFormatter,
+    HelpSection,
+)
 from ._context import Context
 from ._option_groups import (
     GroupedOption,

--- a/cloup/formatting/__init__.py
+++ b/cloup/formatting/__init__.py
@@ -1,0 +1,9 @@
+# flake8: noqa F401
+from ._formatter import (
+    HelpFormatter,
+    HelpSection,
+)
+from ._util import (
+    ensure_is_cloup_formatter,
+    unstyled_len,
+)

--- a/cloup/formatting/_formatter.py
+++ b/cloup/formatting/_formatter.py
@@ -55,7 +55,7 @@ class HelpFormatter(click.HelpFormatter):
       (called ``col_max`` in ``write_dl`` for compatibility with Click).
 
     .. versionchanged:: 0.9.0
-        ``row_sep`` is now ``None`` by default and doesn't have to include a ``\n``
+        ``row_sep`` is now ``None`` by default and doesn't have to include a ``\\n``
         at the end (``row_sep=""`` corresponds to an empty line between rows).
         Furthermore, ``row_sep`` now accepts instances of
         :class:`~cloup.formatting.sep.SepGenerator` and

--- a/cloup/formatting/_util.py
+++ b/cloup/formatting/_util.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 import click
 
 if TYPE_CHECKING:
-    from ._formatter import HelpFormatter
+    from ._formatter import HelpFormatter   # pragma: no cover
 
 FORMATTER_TYPE_ERROR = """
 since cloup v0.8.0, this class relies on cloup.HelpFormatter to align help

--- a/cloup/formatting/_util.py
+++ b/cloup/formatting/_util.py
@@ -1,0 +1,27 @@
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    from ._formatter import HelpFormatter
+
+FORMATTER_TYPE_ERROR = """
+since cloup v0.8.0, this class relies on cloup.HelpFormatter to align help
+sections. So, you need to make sure your command class uses cloup.HelpFormatter
+as formatter class.
+
+If you have your own custom HelpFormatter, know that cloup.HelpFormatter is
+more easily customizable then Click's one, so consider extending it instead
+of extending click.HelpFormatter.
+"""
+
+
+def ensure_is_cloup_formatter(formatter: click.HelpFormatter) -> 'HelpFormatter':
+    from cloup import HelpFormatter
+    if isinstance(formatter, HelpFormatter):
+        return formatter
+    raise TypeError(FORMATTER_TYPE_ERROR)
+
+
+def unstyled_len(string: str) -> int:
+    return len(click.unstyle(string))

--- a/cloup/formatting/sep.py
+++ b/cloup/formatting/sep.py
@@ -1,0 +1,210 @@
+"""
+This module contains anything related to separators. Currently, it contains an
+implementation of "row sep policies", e.g. components that decide if and how to
+add an extra separator/spacing between the rows of a definition list (only for
+tabular layout). In the future, it may be expanded with something analogous for
+help sections.
+"""
+import abc
+import sys
+from itertools import zip_longest
+from typing import Optional, Sequence, Union
+
+if sys.version_info[:2] >= (3, 8):
+    from typing import Protocol
+else:
+    from typing_extensions import Protocol  # pragma: no cover
+
+
+SepType = Union[str, 'SepGenerator']
+
+
+class SepGenerator(Protocol):
+    """Generates a separator given a width. When used as ``row_sep``, this ``width`
+    corresponds to ``HelpFormatter.available_width``, i.e. the line width excluding
+    the current indentation width.
+
+    Note: the length of the returned separator may differ from ``width``.
+    """
+    def __call__(self, width: int) -> str:
+        ...  # pragma: no cover
+
+
+class RowSepPolicy(metaclass=abc.ABCMeta):
+    """A callable that can be passed as ``row_sep`` to  :class:`HelpFormatter` in
+    order to decide *if* a definition list should get a row separator (in
+    addition to ``\\n``) and *which* separator.
+
+    In practice, the row separator should be the same for all definition lists
+    that satisfy a given condition. That's why :class:`RowSepIf`
+    exists, you probably want to use that.
+
+    Nonetheless, this protocol exists mainly for one reason: it leaves open the
+    door to policies that can decide a row separator for each individual row
+    (feature I'm personally against to for now), without breaking changes.
+    This would make possible to implement the old Click 7.2 behavior, which
+    inserted an empty line only after options with a long help. Adding this
+    feature would be possible without breaking changes, by extending the return
+    type to ``Union[None, str, Sequence[str]]``.
+    """
+
+    @abc.abstractmethod
+    def __call__(  # noqa E704
+        self, rows: Sequence[Sequence[str]],
+        col_widths: Sequence[int],
+        col_spacing: int,
+    ) -> Optional[str]:
+        """Decides which row separator to use (eventually none) in the given
+        definition list."""
+
+
+class RowSepCondition(Protocol):
+    """Determines when a definition list should use a row separator."""
+
+    # Ignore error due to flake8 issue: "multiple statements on one line (def)"
+    def __call__(  # noqa E704
+        self, rows: Sequence[Sequence[str]],
+        col_widths: Sequence[int],
+        col_spacing: int,
+    ) -> bool:
+        """Returns ``True`` if the input definition list should use a row
+        separator (in addition to the usual ``\\n``)."""
+
+
+class RowSepIf(RowSepPolicy):
+    def __init__(self, condition: RowSepCondition,
+                 sep: Union[str, SepGenerator] = ''):
+        """
+        Inserts a row separator between the rows of a definition list only if a
+        condition is satisfied. This class implements the ``RowSepPolicy``
+        protocol and does two things:
+
+        - enforces the use of a single row separator for all rows of a
+          definition lists and for all definition lists; note that
+          ``RowSepPolicy`` doesn't for implementation reasons but it's probably
+          what you want;
+        - allows you to implement different conditions (see type
+          :data:`RowSepCondition`) without worrying about the generation part,
+          which is always the same.
+
+        :param condition:
+            a :class:`RowSepCondition` that determines when to add the (extra)
+            row separator.
+        :param sep:
+            either a string or a ``SepGenerator``,
+            i.e. a function ``(width: int) -> str`` (e.g. :class:`Hline`).
+            The empty string corresponds to an empty line separator.
+        """
+        self.condition = condition
+        self.sep = sep
+
+    def __call__(
+        self, rows: Sequence[Sequence[str]], col_widths: Sequence[int], col_spacing: int
+    ) -> Optional[str]:
+        if self.condition(rows, col_widths, col_spacing):
+            if callable(self.sep):
+                total_width = get_total_width(col_widths, col_spacing)
+                return self.sep(total_width)
+            return self.sep
+        return None
+
+
+# ==========================================
+#  Conditions & related utils
+
+def get_total_width(col_widths: Sequence[int], col_spacing: int) -> int:
+    """Returns the total width of a definition list (or, more generally, a table).
+    Useful when implementing a RowSepStrategy."""
+    return sum(col_widths) + col_spacing * (len(col_widths) - 1)
+
+
+def count_multiline_rows(rows: Sequence[str], col_widths: Sequence[int]) -> int:
+    # Note: I'm using zip_longest on purpose so that a TypeError will be raised
+    # if len(row) != len(col_widths). An explicit check is not worth it since
+    # this should never happen.
+    return sum(
+        any(len(col_text) > col_width
+            for col_text, col_width in zip_longest(row, col_widths))
+        for row in rows
+    )
+
+
+def multiline_rows_are_at_least(
+    count_or_percentage: Union[int, float]
+) -> RowSepCondition:
+    """
+    Returns a ``RowSepStrategy`` that returns a row separator between all rows
+    of a definition list, only if the number of rows taking multiple lines is
+    greater than or equal to a certain threshold.
+
+    :param count_or_percentage:
+        a threshold for multiline rows above which the returned strategy will
+        insert a row separator. It can be either an absolute count (`int`) or a
+        percentage relative to the total number of rows expressed as a `float`
+        between 0 and 1 (0 and 1 excluded).
+    """
+    if count_or_percentage <= 0:
+        raise ValueError('count_or_percentage should be > 0')
+
+    if isinstance(count_or_percentage, int):
+        count_threshold = count_or_percentage
+
+        def condition(rows, col_widths, col_spacing):
+            num_multiline = count_multiline_rows(rows, col_widths)
+            return num_multiline >= count_threshold
+
+    elif isinstance(count_or_percentage, float):
+        percent_threshold = count_or_percentage
+        if percent_threshold > 1.0:
+            raise ValueError(
+                "count_or_percentage must be either an integer or a float in the "
+                f"interval ]0, 1[. You passed a float >= 1.0 ({percent_threshold}).")
+
+        def condition(rows, col_widths, col_spacing):
+            num_multiline = count_multiline_rows(rows, col_widths)
+            percent_multiline = num_multiline / len(rows)
+            return percent_multiline >= percent_threshold
+    else:
+        raise TypeError('count_or_percentage must be an int or a float')
+
+    return condition
+
+
+class Hline(SepGenerator):
+    # Workaround: PyCharm auto-completion doesn't work without these declarations
+    solid: 'Hline'
+    dashed: 'Hline'
+    densely_dashed: 'Hline'
+    dotted: 'Hline'
+
+    def __init__(self, pattern: str):
+        """Returns a function that generates an horizontal line of a given length.
+
+        This class has different static members for different line styles
+        like ``Hline.solid``, ``Hline.dashed``, ``Hline.densely_dashed``
+        and  ``Hline.dotted``.
+
+        :param pattern: a string (usually a single character) that is repeated to
+        generate the line.
+        """
+        self.pattern = pattern
+
+    def __call__(self, width: int) -> str:
+        pattern = self.pattern
+        if len(pattern) == 1:
+            return pattern * width
+        reps, rest = width // len(pattern), width % len(pattern)
+        return pattern * reps + pattern[:rest]
+
+
+Hline.solid = Hline("─")
+"""Returns a line like ``────────``."""
+
+Hline.dashed = Hline('-')
+"""Returns a line like ``--------``."""
+
+Hline.densely_dashed = Hline('╌')
+"""Returns a line like ``╌╌╌╌╌╌╌╌``."""
+
+Hline.dotted = Hline("┄")
+"""Returns a line like ``┄┄┄┄┄┄┄┄``."""

--- a/docs/pages/formatting.rst
+++ b/docs/pages/formatting.rst
@@ -294,49 +294,51 @@ a large number, possibly ``math.inf``.
 Row separators
 --------------
 You can specify how to separate the rows/entries of a definition list using the
-``row_sep`` argument of ``HelpFormatter``. Most people would use this to insert
-an empty line between definitions in order to improve readability.
+``row_sep`` argument of ``HelpFormatter``. You may want to use this argument to
+separate definitions with an empty line in order to improve readability.
 
 .. note::
-    - The separator is inserted *in addition* to the usual ``\n`` that separates the
-      rows by default; so, if you want an empty line between definition, you must
-      pass ``row_sep='\n'``.
-    - ``row_sep`` affects only the "tabular layout" (not the linear layout).
+    ``row_sep`` only affects the "tabular layout", not the linear layout.
 
 A constant separator
 ~~~~~~~~~~~~~~~~~~~~
-To use a separator consistently for all definition lists, you can either pass a
-string:
+To use a separator consistently for all definition lists, you can either pass
+either:
+
+- a string
+- or a function ``(width: int) -> str`` that generates such a string based
+  on the width of the definition list; this allows you to pass an instance of
+  :class:`~cloup.formatting.sep.Hline` if you want to use horizontal lines.
+  Note that ``Hline`` is an utility that you can use in other parts of your
+  program as well.
+
+When specifying a separator, you can assume that all rows terminates with a
+newline character. Furthermore, the separator doesn't need to end with a newline
+character because the formatter will write one just after the separator.
 
 .. code-block:: python
 
-    row_sep='\n'   # separates all definitions with an empty line
+    # No row separator (default)
+    row_sep=None
 
-or a ``SepGenerator``, i.e. a function ``(width: int) -> str`` that generates a
-separator based on the width of the definition list. Cloup provides the class
-:class:`~cloup.formatting.sep.Hline`, which has static instances for different
-line styles:
+    # Separate rows with an empty line
+    row_sep=''
 
-.. code-block:: python
-
-    # Built-in lines
+    # Horizontal lines (various styles)
     row_sep=Hline.solid
     row_sep=Hline.dashed
     row_sep=Hline.densely_dashed
     row_sep=Hline.dotted
 
-    # Hline takes a string that is repeated to generate a line
-    row_sep=Hline('-.')   # -.-.-.-.-.
-
 
 Using a separator conditionally
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 A fixed separator gives a consistent look to your help page but has the
-drawback of adding the separator even when unneeded, wasting vertical space,
-e.g. in the "Commands" section.
+drawback of adding the separator even when unneeded (e.g. in the "Commands"
+section), wasting vertical space.
 
 To overcome this problem, Cloup allows you to specify a "policy" that decides
-for each individual definition list whether to use a row separator (and which
+**for each individual definition list** whether to use a row separator (and which
 one). Such policy must implement the :class:`~cloup.formatting.sep.RowSepPolicy`
 interface.
 
@@ -344,12 +346,14 @@ In practice, you will use :class:`~cloup.formatting.sep.RowSepIf`, which takes
 the following parameters:
 
 **condition**
-   a :class:`~cloup.formatting.sep.RowSepCondition` which determines when the
-   separator should be inserted based on the properties of a definition list
+   a :class:`~cloup.formatting.sep.RowSepCondition`, i.e. a function that decides,
+   based on the available horizontal space, if a definition list should use a
+   row separator or not
 
 **sep**
-   a string or a ``SepGenerator``. The default separator is ``sep=""``, which
-   corresponds to an empty line between rows.
+   the separator to use in definition lists that satisfy the ``condition``.
+   This may be a string or a ``SepGenerator``. The default separator is
+   ``sep=""``, which corresponds to an empty line between rows.
 
 Cloup provides the function :func:`~cloup.formatting.sep.multiline_rows_are_at_least`
 to create conditions that enable the use of a separator only if the number of rows
@@ -359,12 +363,10 @@ in the definition list:
 
 .. code-block:: python
 
-    # Insert an empty line between rows only if the definition list has
-    # at least 1 multi-line
+    # Insert an empty line only if the definition list has at least 1 multi-line row
     row_sep=RowSepIf(multiline_rows_are_at_least(1))
 
-    # Insert a dotted line between rows only if at least 25% of all rows
-    # take multiple lines
+    # Insert a dotted line only if at least 25% of all rows take multiple lines
     row_sep=RowSepIf(multiline_rows_are_at_least(.25), sep=Hline.dotted)
 
 

--- a/docs/pages/formatting.rst
+++ b/docs/pages/formatting.rst
@@ -289,6 +289,84 @@ You can disable the linear layout settings ``min_col2_width=0``.
 You make the linear layout your default layout by settings ``min_col2_width`` to
 a large number, possibly ``math.inf``.
 
+.. _row-separators:
+
+Row separators
+--------------
+You can specify how to separate the rows/entries of a definition list using the
+``row_sep`` argument of ``HelpFormatter``. Most people would use this to insert
+an empty line between definitions in order to improve readability.
+
+.. note::
+    - The separator is inserted *in addition* to the usual ``\n`` that separates the
+      rows by default; so, if you want an empty line between definition, you must
+      pass ``row_sep='\n'``.
+    - ``row_sep`` affects only the "tabular layout" (not the linear layout).
+
+A constant separator
+~~~~~~~~~~~~~~~~~~~~
+To use a separator consistently for all definition lists, you can either pass a
+string:
+
+.. code-block:: python
+
+    row_sep='\n'   # separates all definitions with an empty line
+
+or a ``SepGenerator``, i.e. a function ``(width: int) -> str`` that generates a
+separator based on the width of the definition list. Cloup provides the class
+:class:`~cloup.formatting.sep.Hline`, which has static instances for different
+line styles:
+
+.. code-block:: python
+
+    # Built-in lines
+    row_sep=Hline.solid
+    row_sep=Hline.dashed
+    row_sep=Hline.densely_dashed
+    row_sep=Hline.dotted
+
+    # Hline takes a string that is repeated to generate a line
+    row_sep=Hline('-.')   # -.-.-.-.-.
+
+
+Using a separator conditionally
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+A fixed separator gives a consistent look to your help page but has the
+drawback of adding the separator even when unneeded, wasting vertical space,
+e.g. in the "Commands" section.
+
+To overcome this problem, Cloup allows you to specify a "policy" that decides
+for each individual definition list whether to use a row separator (and which
+one). Such policy must implement the :class:`~cloup.formatting.sep.RowSepPolicy`
+interface.
+
+In practice, you will use :class:`~cloup.formatting.sep.RowSepIf`, which takes
+the following parameters:
+
+**condition**
+   a :class:`~cloup.formatting.sep.RowSepCondition` which determines when the
+   separator should be inserted based on the properties of a definition list
+
+**sep**
+   a string or a ``SepGenerator``. The default separator is ``sep=""``, which
+   corresponds to an empty line between rows.
+
+Cloup provides the function :func:`~cloup.formatting.sep.multiline_rows_are_at_least`
+to create conditions that enable the use of a separator only if the number of rows
+taking multiple lines is above a certain threshold. The threshold can be specified
+either as an absolute number or as a percentage relative the total number of rows
+in the definition list:
+
+.. code-block:: python
+
+    # Insert an empty line between rows only if the definition list has
+    # at least 1 multi-line
+    row_sep=RowSepIf(multiline_rows_are_at_least(1))
+
+    # Insert a dotted line between rows only if at least 25% of all rows
+    # take multiple lines
+    row_sep=RowSepIf(multiline_rows_are_at_least(.25), sep=Hline.dotted)
+
 
 Minor differences with Click
 ----------------------------

--- a/examples/manim/main.py
+++ b/examples/manim/main.py
@@ -4,7 +4,14 @@ This example shows how a real-world application could look like and serves to me
 as a test bench for trying out styling and formatting.
 """
 import cloup
-from cloup import Color, Context, HelpFormatter, HelpTheme, Style
+from cloup import (
+    Color,
+    Context,
+    HelpFormatter,
+    HelpTheme,
+    Style,
+)
+from cloup.formatting.sep import RowSepIf, multiline_rows_are_at_least
 from config import cfg
 from render import render
 
@@ -20,7 +27,10 @@ CONTEXT_SETTINGS = Context.settings(
         # col1_max_width=30
         # col2_min_width=35,
         # indent_increment=2,
-        # row_sep='\n',
+        row_sep=RowSepIf(
+            multiline_rows_are_at_least(0.35),
+            # sep=Hline.densely_dashed
+        ),
         theme=HelpTheme.dark().with_(
             # invoked_command=Style(...),
             # command_help=Style(...),

--- a/setup.py
+++ b/setup.py
@@ -48,5 +48,6 @@ setup(
     install_requires=[
         'click >=7.1, <9.0',
         'dataclasses; python_version<="3.6"',
+        'typing_extensions; python_version<="3.8"',
     ],
 )

--- a/tests/test_sep.py
+++ b/tests/test_sep.py
@@ -1,0 +1,68 @@
+from functools import partial
+
+import pytest
+
+from cloup.formatting.sep import Hline, count_multiline_rows, multiline_rows_are_at_least
+
+# Use the same widths for both columns
+cols_width = 30
+col_widths = (cols_width, cols_width)
+col_spacing = 2
+
+# We'll use these in many tests (a = above_limit, b = below_limit)
+above_limit = 'a' * (cols_width + 1)
+below_limit = 'b' * cols_width
+aa = (above_limit, above_limit)
+ab = (above_limit, below_limit)
+ba = (below_limit, above_limit)
+bb = (below_limit, below_limit)
+
+
+def test_Hline():
+    assert Hline.solid(5) == "─────"
+    assert Hline.dashed(5) == "-----"
+    assert Hline.densely_dashed(5) == "╌╌╌╌╌"
+    assert Hline.dotted(5) == "┄┄┄┄┄"
+    assert Hline('-.')(5) == '-.-.-'
+
+
+def test_count_multiline_rows():
+    count = partial(count_multiline_rows, col_widths=col_widths)
+    assert count([bb]) == 0
+    assert count([ba]) == 1
+    assert count([ab]) == 1
+    assert count([aa]) == 1
+    assert count([bb, ba, ab, aa]) == 3
+    with pytest.raises(Exception):
+        count([tuple('1234')])  # len(row) > len(col_widths)
+
+
+class TestMultilineRowsAreAtLeast:
+    @pytest.mark.parametrize('bad_value', [0, 0.0, -1, -1.4, 1.1, 11.0])
+    def test_args_validation(self, bad_value):
+        with pytest.raises(ValueError):
+            multiline_rows_are_at_least(bad_value)
+
+    def test_with_count(self):
+        at_least_2_multiline_rows = partial(multiline_rows_are_at_least(2),
+                                            col_widths=(30, 30), col_spacing=2)
+        assert at_least_2_multiline_rows([ab, bb, bb, ba])
+        assert at_least_2_multiline_rows([ab, bb, bb, ba, aa])
+        assert not at_least_2_multiline_rows([bb, bb, bb])
+
+    def test_with_percentage(self):
+        at_least_half_multiline_rows = partial(multiline_rows_are_at_least(.5),
+                                               col_widths=(30, 30), col_spacing=2)
+        assert at_least_half_multiline_rows([
+            bb, bb, bb,
+            aa, ab, ba,
+        ])
+        assert at_least_half_multiline_rows([
+            bb, bb, bb,
+            aa, ab, ba, aa, ab
+        ])
+        assert not at_least_half_multiline_rows([
+            bb, bb, bb, bb,
+            aa, ab, ba,
+        ])
+        assert not at_least_half_multiline_rows([bb] * 5)


### PR DESCRIPTION
1. Set it to `None` by default and write a `\n` after it (closes #41).
2. Insert `row_sep` only in between rows (closes #36).
3. Define `SepGenerator` as a protocol and allow to pass a generator to `row_sep` (closes #39).
4. Implement a `SepGenerator` for horizontal lines, `Hline`.
5. Define a `RowSepPolicy` base class and implement it with `RowSepIf` (closes #37).