### PR TITLE
Add detailed type annotations for param and command decorators, explicitly listing all kwargs

### DIFF
--- a/cloup/__init__.py
+++ b/cloup/__init__.py
@@ -9,7 +9,6 @@ __version_tuple__ = _version.version_tuple
 
 # flake8: noqa F401
 from click import (
-    argument,
     confirmation_option,
     help_option,
     pass_context,
@@ -29,11 +28,10 @@ from .formatting import (
     HelpSection,
 )
 from ._context import Context
+from ._params import GroupedOption, argument, option
 from ._option_groups import (
-    GroupedOption,
     OptionGroup,
     OptionGroupMixin,
-    option,
     option_group,
 )
 from ._sections import (

--- a/cloup/_option_groups.py
+++ b/cloup/_option_groups.py
@@ -216,7 +216,7 @@ def option(
     group: Optional[OptionGroup] = None,
     cls: Type[click.Option] = GroupedOption,
     **attrs
-) -> OptionGroupAdder:
+) -> OptionAdder:
     def decorator(f):
         func = click.option(*param_decls, cls=cls, **attrs)(f)
         new_option = func.__click_params__[-1]

--- a/cloup/_params.py
+++ b/cloup/_params.py
@@ -1,0 +1,34 @@
+import click
+
+
+class GroupedOption(click.Option):
+    """A click.Option with an extra field ``group`` of type ``OptionGroup``."""
+
+    def __init__(self, *args, group=None, **attrs):
+        super().__init__(*args, **attrs)
+        self.group = group
+
+
+argument = click.argument
+
+
+def option(
+    *param_decls,
+    cls=GroupedOption,
+    group=None,
+    **kwargs
+):
+    """Attaches an ``Option`` to the command.
+    Refer to :class:`click.Option` and :class:`click.Parameter` for more info
+    about the accepted parameters.
+    """
+
+    def decorator(f):
+        func = click.option(*param_decls, cls=cls, **kwargs)(f)
+        new_option = func.__click_params__[-1]
+        new_option.group = group
+        if group and group.hidden:
+            new_option.hidden = True
+        return func
+
+    return decorator

--- a/cloup/_params.pyi
+++ b/cloup/_params.pyi
@@ -1,0 +1,99 @@
+"""
+Types for parameter decorators are in this stub for convenience of implementation.
+"""
+from typing import Any, Callable, Optional, Sequence, Type, TypeVar, Union
+
+import click
+
+from cloup._util import C
+from cloup import OptionGroup
+
+ArgumentAdder = Callable[[C], C]
+"""A decorator that attaches an Argument to a function."""
+
+OptionAdder = Callable[[C], C]
+"""A decorator that attaches an Option to a function."""
+
+P = TypeVar('P', bound=click.Parameter)
+
+ParamTypeLike = Union[
+    click.ParamType,
+    Type[float], Type[int],
+    Type[str], Type[tuple],
+]
+ParamDefault = Union[Any, Callable[[], Any]]
+ParamCallback = Callable[[click.Context, P, Any], Any]
+
+# Click 8 deprecates the argument `autocompletion` and replaces it with the
+# argument `shell_complete`, which has a different semantic.
+# The following will be uncommented when Cloup drop support for Click 7:
+#
+# ShellComplete = Callable[
+#     [click.Context, P, str],
+#     Union[List['CompletionItem'], List[str]],
+# ]
+
+
+class GroupedOption(click.Option):
+    def __init__(
+        self, *args, group: Optional[OptionGroup] = None, **kwargs
+    ): ...
+
+
+def argument(
+    *param_decls,
+    cls: Optional[Type[click.Argument]] = None,
+    type: Optional[ParamTypeLike] = None,
+    required: Optional[bool] = None,
+    default: Optional[ParamDefault] = None,
+    callback: Optional[ParamCallback[click.Argument]] = None,
+    nargs: Optional[int] = None,
+    metavar: Optional[str] = None,
+    expose_value: bool = True,
+    envvar: Optional[Union[str, Sequence[str]]] = None,
+    # The following will be added when Cloup drops support for Click 7:
+    #     shell_complete: Optional[ShellComplete] = None,
+    **kwargs
+) -> ArgumentAdder: ...
+
+
+def option(
+    *param_decls,
+    cls: Optional[Type[click.Option]] = None,
+    # Commonly used
+    metavar: Optional[str] = None,
+    type: Optional[ParamTypeLike] = None,
+    is_flag: Optional[bool] = None,
+    default: Optional[ParamDefault] = None,
+    required: Optional[bool] = None,
+    help: Optional[str] = None,
+    # Processing
+    callback: Optional[ParamCallback[click.Option]] = None,
+    is_eager: bool = False,
+    # Help text tuning
+    show_choices: bool = True,
+    show_default: bool = False,
+    show_envvar: bool = False,
+    # Flag options
+    flag_value: Optional[Any] = None,
+    count: bool = False,
+    # Multiple values
+    nargs: Optional[int] = None,
+    multiple: bool = False,
+    # Prompt
+    prompt: Union[bool, str] = False,
+    confirmation_prompt: Union[bool, str] = False,
+    prompt_required: bool = True,
+    hide_input: bool = False,
+    # Environment
+    allow_from_autoenv: bool = True,
+    envvar: Optional[Union[str, Sequence[str]]] = None,
+    # Hiding
+    hidden: bool = False,
+    expose_value: bool = True,
+    # Others
+    group: Optional[OptionGroup] = None,
+    # The following will be added when Cloup drops support for Click 7:
+    #     shell_complete: Optional[ShellComplete] = None,
+    **kwargs
+) -> OptionAdder: ...

--- a/cloup/_util.py
+++ b/cloup/_util.py
@@ -1,13 +1,15 @@
 """Generic utilities."""
 from enum import Enum
-from typing import Any, Dict, Iterable, List, Optional, TypeVar, Union
+from typing import (
+    Any, Callable, Dict, Hashable, Iterable, List, Optional, Sequence, TypeVar, Union
+)
 
 import click
 
 click_version_tuple = click.__version__.split('.')
 
 T = TypeVar('T')
-K = TypeVar('K')
+K = TypeVar('K', bound=Hashable)
 V = TypeVar('V')
 
 
@@ -21,7 +23,7 @@ NULL = _Null.token
 Possibly = Union[_Null, T]
 
 
-def pick_non_null(d: Dict[K, V]) -> Dict[K, V]:
+def pick_non_null(d: Dict[K, Possibly[V]]) -> Dict[K, V]:
     return {key: val for key, val in d.items() if val is not NULL}
 
 

--- a/cloup/_util.py
+++ b/cloup/_util.py
@@ -8,6 +8,9 @@ import click
 
 click_version_tuple = click.__version__.split('.')
 
+# Click-related type vars
+C = TypeVar('C', bound=Callable)
+
 T = TypeVar('T')
 K = TypeVar('K', bound=Hashable)
 V = TypeVar('V')
@@ -141,7 +144,6 @@ class FrozenSpace(metaclass=FrozenSpaceMeta):
             "this class is just a namespace for constants, it's not instantiable.")
 
 
-def pop_many(d: dict, *keys: str) -> dict:
+def delete_keys(d: dict, keys: Sequence[str]) -> None:
     for key in keys:
-        d.pop(key)
-    return d
+        del d[key]

--- a/cloup/styling.py
+++ b/cloup/styling.py
@@ -7,7 +7,7 @@ from typing import Callable, NamedTuple, Optional
 
 import click
 
-from cloup._util import FrozenSpace, click_version_tuple, identity, pop_many
+from cloup._util import FrozenSpace, click_version_tuple, delete_keys, identity
 
 IStyle = Callable[[str], str]
 """A callable that takes a string and returns a styled version of it."""
@@ -153,10 +153,11 @@ class Style:
 
     def __call__(self, text: str) -> str:
         if self._style_kwargs is None:
-            kwargs = pop_many(dc.asdict(self), 'text_transform', '_style_kwargs')
+            kwargs = dc.asdict(self)
+            delete_keys(kwargs, ['text_transform', '_style_kwargs'])
             if int(click_version_tuple[0]) < 8:
                 # These arguments are not supported in Click < 8. Ignore them.
-                pop_many(kwargs, 'overline', 'italic', 'strikethrough')
+                delete_keys(kwargs, ['overline', 'italic', 'strikethrough'])
             object.__setattr__(self, '_style_kwargs', kwargs)
         else:
             kwargs = self._style_kwargs

--- a/examples/manim/render.py
+++ b/examples/manim/render.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from pprint import pprint
 
 import click
@@ -8,7 +7,7 @@ from cloup import argument, option, option_group
 
 
 @cloup.command()
-@argument("script_path", type=Path, required=True)
+@argument("script_path", type=click.Path(), required=True)
 @argument("scene_names", required=False, nargs=-1)
 @option_group(
     "Global options",


### PR DESCRIPTION
Closes #21.

### Why a stub file?
I used a stub .pyi file for annotating `@argument` and `@option`. This was convenient because of how Click handles arguments passed to these decorators, sometimes assuming an argument is not `None` just because it is in `**kwargs`. For this reasons, arguments must be collected and processed to remove all `None`. Given the large number of arguments in these decorators, this also has a performance impact (arguably irrelevant, but still an order of magnitude increase). 

### Work left out for the future
- (#46) Make all arguments of `@command` and `@group` but `name` keyword-only.
- **Autocompletion arguments.** The arguments:
  - `autocompletion`, which is deprecated in Click 8.0 and will be removed in Click 8.1 
  - `shell_complete`, which supersedes the previous

  were not included because Cloup currently supports both `click >= 7.2`. I'll add `shell_complete` when support for Click 7 is dropped.