### PR TITLE
Make all arguments of @command and @group but `name` keyword-only

### DIFF
--- a/cloup/_commands.py
+++ b/cloup/_commands.py
@@ -156,6 +156,7 @@ class Group(SectionMixin, BaseCommand, click.Group):
 # noinspection PyIncorrectDocstring
 def group(
     name: Optional[str] = None,
+    *,
     cls: Type[Group] = Group,
     invoke_without_command: bool = False,
     no_args_is_help: bool = False,
@@ -196,6 +197,7 @@ def group(
 
 def command(
     name: Optional[str] = None,
+    *,
     cls: Type[click.Command] = Command,
     context_settings: Optional[Dict[str, Any]] = None,
     help: Optional[str] = None,


### PR DESCRIPTION
Closes #46.

Note that `Group.command` and `Group.group` are not affected since they need to stay fully compatible with Click (not to break the Liskov's substitution principle). Those methods are not even affected by PR #47.