### PR TITLE
Refine command decorators

### DIFF
--- a/cloup/_commands.py
+++ b/cloup/_commands.py
@@ -158,9 +158,12 @@ def group(
     name: Optional[str] = None,
     *,
     cls: Type[Group] = Group,
+    sections: Iterable[Section] = (),
+    align_sections: Optional[bool] = None,
     invoke_without_command: bool = False,
     no_args_is_help: bool = False,
     context_settings: Optional[Dict[str, Any]] = None,
+    formatter_settings: Dict[str, Any] = {},
     help: Optional[str] = None,
     epilog: Optional[str] = None,
     short_help: Optional[str] = None,
@@ -190,6 +193,13 @@ def group(
         This restricts the form of commands in that they cannot have optional
         arguments but it allows multiple commands to be chained together.
     """
+    if not issubclass(cls, Group):
+        raise TypeError(
+            'this decorator requires cls to be a cloup.Group or a subclass of it. '
+            'Use @click.group to instantiate another type of Group but remember '
+            'that some of the arguments of this decorator are only supported by '
+            'cloup.Group.')
+
     kwargs.update(locals())
     kwargs.pop('kwargs')
     return cast(Callable[[Callable], Group], click.group(**kwargs))

--- a/cloup/_commands.py
+++ b/cloup/_commands.py
@@ -153,7 +153,6 @@ class Group(SectionMixin, BaseCommand, click.Group):
         return self.command(name=name, section=section, cls=cls, **kwargs)
 
 
-# noinspection PyIncorrectDocstring
 def group(
     name: Optional[str] = None,
     *,
@@ -175,9 +174,43 @@ def group(
     deprecated: bool = False,
     **kwargs
 ) -> Callable[[Callable], Group]:
-    """Decorator for creating a new :class:`Group`.
-    This function takes the same arguments of :func:`command` plus the following:
+    """Decorator for creating a new :class:`cloup.Group` (or a subclass of it).
 
+    :param name:
+        the name of the command to use unless a group overrides it.
+    :param cls:
+        the ``cloup.Group`` (sub)class to instantiate.
+    :param sections:
+        a list of Section objects.
+    :param align_sections:
+        if ``True``, the help column of all columns will be aligned;
+        if ``False``, each section will be formatted independently.
+    :param context_settings:
+        an optional dictionary with defaults that are passed to the context object.
+    :param formatter_settings:
+        arguments for the formatter; you can use :meth:`HelpFormatter.settings`
+        to build this dictionary.
+    :param help:
+        the help string to use for this command.
+    :param epilog:
+        like the help string but it's printed at the end of the help page after
+        everything else.
+    :param short_help:
+        the short help to use for this command.  This is shown on the command
+        listing of the parent command.
+    :param options_metavar:
+        metavar for options shown in the command's usage string.
+    :param add_help_option:
+        by default each command registers a ``--help`` option.
+        This can be disabled by this parameter.
+    :param no_args_is_help:
+        this controls what happens if no arguments are provided. This option is
+        disabled by default. If enabled this will add ``--help`` as argument if
+        no arguments are passed
+    :param hidden:
+        hide this command from help outputs.
+    :param deprecated:
+        issues a message indicating that the command is deprecated.
     :param invoke_without_command:
         this controls how the multi command itself is invoked. By default it's
         only invoked if a subcommand is provided.
@@ -192,6 +225,8 @@ def group(
         if this is set to `True` chaining of multiple subcommands is enabled.
         This restricts the form of commands in that they cannot have optional
         arguments but it allows multiple commands to be chained together.
+    :param kwargs:
+        any other argument accepted by the instantiated command class.
     """
     if not issubclass(cls, Group):
         raise TypeError(
@@ -225,8 +260,17 @@ def command(
 
     The only differences with respect to ``click.commands`` are:
 
-    - this decorator creates a ``cloup.Command`` by default;
-    - this decorator supports ``@constraint``.
+    - the default command class is :class:`cloup.Command`
+    - supports ``@constraint`` (provided that ``cls=cloup.Command``).
+
+    Besides of all the arguments documented below, you can pass any argument
+    accepted by the instantiated command class (``cls``), which in the case of
+    the default (:class:`cloup.Command`) include:
+
+    - ``formatter_settings (dict)`` -- arguments for the formatter; you can use
+      :meth:`HelpFormatter.settings` to build this dictionary.
+    - ``align_option_groups (Optional[bool])``
+    - ``show_constraints (Optional[bool])``.
 
     :param name:
         the name of the command to use unless a group overrides it.
@@ -255,6 +299,8 @@ def command(
         hide this command from help outputs.
     :param deprecated:
         issues a message indicating that the command is deprecated.
+    :param kwargs:
+        any other argument accepted by the instantiated command class.
     """
     kwargs.update(locals())
     kwargs.pop('kwargs')

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,16 @@
+import click
+import pytest
+
+import cloup
+
+
+def test_group_raises_if_cls_is_not_subclass_of_cloup_Group():
+    class GroupSubclass(cloup.Group):
+        pass
+
+    # Shouldn't raise with default arguments
+    cloup.group('ciao')
+    cloup.group(align_sections=True, cls=cloup.Group)
+    cloup.group(align_sections=True, cls=GroupSubclass)
+    with pytest.raises(TypeError):
+        cloup.group(cls=click.Group)


### PR DESCRIPTION
This is the continuation of PR #47.

- Adds Cloup-specific args to `@group` and a check that `cls` is a subclass of `cloup.Group`.
- Improves docstrings.