### PR TITLE
Simplify and improve the `error` argument of `Rephraser`

### DIFF
--- a/cloup/constraints/__init__.py
+++ b/cloup/constraints/__init__.py
@@ -11,6 +11,8 @@ from ._core import (
     AcceptBetween,
     And,
     Constraint,
+    ErrorRephraser,
+    HelpRephraser,
     Operator,
     Or,
     Rephraser,
@@ -22,11 +24,6 @@ from ._core import (
     mutually_exclusive,
     require_all,
 )
-from ._support import (
-    BoundConstraintSpec,
-    ConstraintMixin,
-    constraint,
-    constrained_params,
-)
+from ._support import (BoundConstraintSpec, ConstraintMixin, constrained_params, constraint)
 from .conditions import AllSet, AnySet, Equal, IsSet, Not
 from .exceptions import ConstraintViolated, UnsatisfiableConstraint

--- a/cloup/constraints/_conditional.py
+++ b/cloup/constraints/_conditional.py
@@ -73,7 +73,8 @@ class If(Constraint):
         except ConstraintViolated as err:
             desc = (condition.description(ctx) if condition_is_true
                     else condition.negated_description(ctx))
-            raise ConstraintViolated(f"when {desc}, {err}", ctx=ctx)
+            raise ConstraintViolated(
+                f"when {desc}, {err}", ctx=ctx, constraint=self, params=params)
 
     def __repr__(self) -> str:
         if self._else:

--- a/cloup/constraints/_core.py
+++ b/cloup/constraints/_core.py
@@ -224,7 +224,9 @@ class Or(Operator):
                 return c.check_values(params, ctx)
             except ConstraintViolated:
                 pass
-        raise ConstraintViolated.default(params, self.help(ctx), ctx=ctx)
+        raise ConstraintViolated.default(
+            self.help(ctx), ctx=ctx, constraint=self, params=params
+        )
 
     def __or__(self, other) -> 'Or':
         if isinstance(other, Or):
@@ -282,7 +284,8 @@ class Rephraser(Constraint):
         except ConstraintViolated:
             rephrased_error = self._get_rephrased_error(ctx, params)
             if rephrased_error:
-                raise ConstraintViolated(rephrased_error, ctx=ctx)
+                raise ConstraintViolated(
+                    rephrased_error, ctx=ctx, constraint=self, params=params)
             raise
 
     def __repr__(self):
@@ -341,6 +344,8 @@ class _RequireAll(Constraint):
                     many=f"the following parameters are required:\n"
                          f"{format_param_list(unset_params)}"),
                 ctx=ctx,
+                constraint=self,
+                params=params,
             )
 
 
@@ -370,7 +375,7 @@ class RequireAtLeast(Constraint):
             raise ConstraintViolated(
                 f"at least {n} of the following parameters must be set:\n"
                 f"{format_param_list(params)}",
-                ctx=ctx
+                ctx=ctx, constraint=self, params=params,
             )
 
     def __repr__(self):
@@ -400,7 +405,7 @@ class AcceptAtMost(Constraint):
             raise ConstraintViolated(
                 f"no more than {n} of the following parameters can be set:\n"
                 f"{format_param_list(params)}",
-                ctx=ctx,
+                ctx=ctx, constraint=self, params=params,
             )
 
     def __repr__(self):
@@ -427,7 +432,8 @@ class RequireExactly(WrapperConstraint):
                 zero='none of the following parameters must be set:\n',
                 many=f'exactly {n} of the following parameters must be set:\n'
             ) + format_param_list(params)
-            raise ConstraintViolated(reason, ctx=ctx)
+            raise ConstraintViolated(
+                reason, ctx=ctx, constraint=self, params=params)
 
 
 class AcceptBetween(WrapperConstraint):

--- a/cloup/constraints/_core.py
+++ b/cloup/constraints/_core.py
@@ -283,6 +283,7 @@ class Rephraser(Constraint):
             return None
         elif isinstance(self._error, str):
             return self._error.format(
+                error=str(err),
                 param_list=format_param_list(err.params),
             )
         else:

--- a/cloup/constraints/exceptions.py
+++ b/cloup/constraints/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Optional, TYPE_CHECKING
+from typing import Iterable, Sequence, TYPE_CHECKING
 
 import click
 from click import Context, Parameter
@@ -18,16 +18,28 @@ def default_constraint_error(params: Iterable[Parameter], desc: str) -> str:
 
 class ConstraintViolated(click.UsageError):
     def __init__(
-        self, message: str, ctx: Optional[Context] = None
+        self, message: str,
+        ctx: Context,
+        constraint: 'Constraint',
+        params: Sequence[click.Parameter]
     ):
         super().__init__(message, ctx=ctx)
+        self.ctx = ctx
+        self.constraint = constraint
+        self.params = params
 
     @classmethod
     def default(
-        cls, params: Iterable[Parameter], desc: str, ctx: Optional[Context] = None
+        cls,
+        desc: str,
+        ctx: Context,
+        constraint: 'Constraint',
+        params: Sequence[Parameter],
     ) -> 'ConstraintViolated':
         return ConstraintViolated(
-            default_constraint_error(params, desc), ctx=ctx)
+            default_constraint_error(params, desc),
+            ctx=ctx, constraint=constraint, params=params,
+        )
 
 
 class UnsatisfiableConstraint(Exception):

--- a/tests/constraints/test_constraints.py
+++ b/tests/constraints/test_constraints.py
@@ -297,11 +297,19 @@ class TestRephraser:
 
     def test_error_is_overridden_passing_string(self):
         fake_ctx = make_fake_context(make_options('abcd'))
-        wrapped = FakeConstraint(satisfied=False)
+        wrapped = FakeConstraint(satisfied=False, error='__error__')
         rephrased = Rephraser(wrapped, error='error:\n{param_list}')
         with pytest.raises(ConstraintViolated) as exc_info:
             rephrased.check(['a', 'b'], ctx=fake_ctx)
         assert exc_info.value.message == 'error:\n  --a\n  --b\n'
+
+    def test_error_template_key(self):
+        fake_ctx = make_fake_context(make_options('abcd'))
+        wrapped = FakeConstraint(satisfied=False, error='__error__')
+        rephrased = Rephraser(wrapped, error='{error}\nExtra info here.')
+        with pytest.raises(ConstraintViolated) as exc_info:
+            rephrased.check(['a', 'b'], ctx=fake_ctx)
+        assert str(exc_info.value) == '__error__\nExtra info here.'
 
     def test_error_is_overridden_passing_function(self):
         params = make_options('abc')

--- a/tests/constraints/test_constraints.py
+++ b/tests/constraints/test_constraints.py
@@ -51,7 +51,7 @@ class FakeConstraint(Constraint):
     def check_values(self, params: Sequence[Parameter], ctx: Context):
         self.check_values_calls.append(dict(params=params, ctx=ctx))
         if not self.satisfied:
-            raise ConstraintViolated(self.error, ctx=ctx)
+            raise ConstraintViolated(self.error, ctx=ctx, constraint=self, params=params)
 
 
 class TestBaseConstraint:


### PR DESCRIPTION
The `error` argument is of type `Union[None, str, ErrorRephraser]`. 

`ErrorRephraser` was redefined (**breaking change**) from:
```python
(ctx: Context, constraint: Constraint, params: Sequence[params]) -> str
```
to:
```python
(err: ConstraintViolated) -> str
```

This was possible without making it less powerful by enriching `ConstraintViolated`, which now takes all three arguments that `ErrorRephraser` took separately: `ctx, constraint` and `params`. (**breaking change**)

This also means that an `ErrorRephraser` can now easily reuse the original error, which is useful if all you want is to add extra info before or after the original error!  Example:
```python
mutually_exclusive.rephrased(
    error=lambda err: f"{err}.\nUse --renderer, the other two options are deprecated."
)(
    option(
        "--renderer",
        type=click.Choice(["cairo", "opengl", "webgl"], case_sensitive=False),
        help="Select a renderer for your Scene.",
    ),
    option(
        "--use_opengl_renderer", is_flag=True, hidden=True,
        help="(Deprecated) Use --renderer=opengl.",
    ),
    option(
        "--use_cairo_renderer", is_flag=True, hidden=True,
        help="(Deprecated) Use --renderer=cairo.",
    ),
)
```

The original message is also available as format string field `{error}`. So the following is equivalent to the above code:
```python
mutually_exclusive.rephrased(
    error="{error}.\nUse --renderer, the other two options are deprecated."
)(...)
```

