### PR TITLE
Add `ErrorFmt`, a `FrozenSpace` containing fields supported by `error` format string of `Rephraser` 

### DIFF
--- a/cloup/constraints/__init__.py
+++ b/cloup/constraints/__init__.py
@@ -11,6 +11,7 @@ from ._core import (
     AcceptBetween,
     And,
     Constraint,
+    ErrorFmt,
     ErrorRephraser,
     HelpRephraser,
     Operator,
@@ -24,6 +25,11 @@ from ._core import (
     mutually_exclusive,
     require_all,
 )
-from ._support import (BoundConstraintSpec, ConstraintMixin, constrained_params, constraint)
+from ._support import (
+    BoundConstraintSpec,
+    ConstraintMixin,
+    constraint,
+    constrained_params,
+)
 from .conditions import AllSet, AnySet, Equal, IsSet, Not
 from .exceptions import ConstraintViolated, UnsatisfiableConstraint

--- a/cloup/constraints/_core.py
+++ b/cloup/constraints/_core.py
@@ -155,6 +155,7 @@ class Constraint(abc.ABC):
         :param help:
             if provided, overrides the help string of this constraint. It can be
             a string or a function ``(ctx: Context, constr: Constraint) -> str``.
+            If you want to hide this constraint from the help, pass ``help=""``.
         :param error:
             if provided, overrides the error message of this constraint.
             It can be:

--- a/cloup/constraints/_core.py
+++ b/cloup/constraints/_core.py
@@ -6,7 +6,9 @@ from typing import (
 import click
 from click import Context, Parameter
 
-from cloup._util import C, check_arg, class_name, make_one_line_repr, make_repr, pluralize
+from cloup._util import (
+    C, FrozenSpace, check_arg, class_name, make_one_line_repr, make_repr, pluralize
+)
 from .common import (
     format_param_list,
     get_param_label,
@@ -157,7 +159,9 @@ class Constraint(abc.ABC):
             if provided, overrides the error message of this constraint.
             It can be:
 
-            - a template string for the ``format`` built-in function
+            - a string, eventually a ``format`` string supporting the replacement
+              fields described in :class:`ErrorFmt`.
+
             - or a function ``(err: ConstraintViolated) -> str``; note that
               a :class:`ConstraintViolated` error has fields for ``ctx``,
               ``constraint`` and ``params``, so it's a complete description
@@ -251,12 +255,38 @@ class Or(Operator):
         return Or(*self.constraints, other)
 
 
+class ErrorFmt(FrozenSpace):
+    """:class:`Rephraser` allows you to pass a ``format`` string as ``error``
+    argument; this class contains the "replacement fields" supported by such
+    format string. You can use them as following::
+
+        mutually_exclusive.rephrased(
+            error=f"{ErrorFmt.error}\\n"
+                  f"Some extra information here."
+        )
+    """
+
+    error = '{error}'
+    """Replaced by the original error message. Useful if all you want is to
+    append or prepend some extra info to the original error message."""
+
+    param_list = '{param_list}'
+    """Replaced by a 2-space indented list of the constrained parameters."""
+
+
 class Rephraser(Constraint):
     """A Constraint decorator that can override the help and/or the error
     message of the wrapped constraint.
 
+    You'll rarely (if ever) use this class directly. In most cases, you'll use
+    the method :meth:`Constraint.rephrased`. Refer to it for more info.
+
     .. seealso::
-        :class:`WrapperConstraint`.
+
+        - :meth:`Constraint.rephrased` -- wraps a constraint with a ``Rephraser``.
+        - :class:`WrapperConstraint` -- alternative to ``Rephraser``.
+        - :class:`ErrorFmt` -- describes the keyword you can use in an error
+          format string.
     """
 
     def __init__(
@@ -478,19 +508,22 @@ require_all = _RequireAll()
 
 accept_none = AcceptAtMost(0).rephrased(
     help='all forbidden',
-    error='the following parameters should not be provided:\n{param_list}'
+    error=f'the following parameters should not be provided:\n'
+          f'{ErrorFmt.param_list}'
 )
 """Satisfied if none of the parameters is set. Useful only in conditional constraints."""
 
 all_or_none = (require_all | accept_none).rephrased(
     help='provide all or none',
-    error='the following parameters should be provided together (or none of '
-          'them should be provided):\n{param_list}',
+    error=f'the following parameters should be provided together (or none of '
+          f'them should be provided):\n'
+          f'{ErrorFmt.param_list}',
 )
 """Satisfied if either all or none of the parameters are set."""
 
 mutually_exclusive = AcceptAtMost(1).rephrased(
     help='mutually exclusive',
-    error='the following parameters are mutually exclusive:\n{param_list}'
+    error=f'the following parameters are mutually exclusive:\n'
+          f'{ErrorFmt.param_list}'
 )
 """Satisfied if at most one of the parameters is set."""

--- a/examples/manim/render.py
+++ b/examples/manim/render.py
@@ -4,7 +4,7 @@ import click
 
 import cloup
 from cloup import argument, option, option_group
-from cloup.constraints import mutually_exclusive
+from cloup.constraints import ErrorFmt, mutually_exclusive
 
 
 @cloup.command()
@@ -98,7 +98,9 @@ from cloup.constraints import mutually_exclusive
         "--fps", "--frame_rate", "frame_rate", type=float,
         help="Render at this frame rate.",
     ),
-    mutually_exclusive(
+    mutually_exclusive.rephrased(
+        error=f"{ErrorFmt.error}.\nUse --renderer, the other two options are deprecated."
+    )(
         option(
             "--renderer",
             type=click.Choice(["cairo", "opengl", "webgl"], case_sensitive=False),

--- a/tests/constraints/test_constraints.py
+++ b/tests/constraints/test_constraints.py
@@ -12,6 +12,7 @@ from cloup.constraints import (
     AcceptAtMost,
     AcceptBetween,
     Constraint,
+    ErrorFmt,
     Rephraser,
     RequireAtLeast,
     RequireExactly,
@@ -298,7 +299,7 @@ class TestRephraser:
     def test_error_is_overridden_passing_string(self):
         fake_ctx = make_fake_context(make_options('abcd'))
         wrapped = FakeConstraint(satisfied=False, error='__error__')
-        rephrased = Rephraser(wrapped, error='error:\n{param_list}')
+        rephrased = Rephraser(wrapped, error=f'error:\n{ErrorFmt.param_list}')
         with pytest.raises(ConstraintViolated) as exc_info:
             rephrased.check(['a', 'b'], ctx=fake_ctx)
         assert exc_info.value.message == 'error:\n  --a\n  --b\n'
@@ -306,7 +307,7 @@ class TestRephraser:
     def test_error_template_key(self):
         fake_ctx = make_fake_context(make_options('abcd'))
         wrapped = FakeConstraint(satisfied=False, error='__error__')
-        rephrased = Rephraser(wrapped, error='{error}\nExtra info here.')
+        rephrased = Rephraser(wrapped, error=f'{ErrorFmt.error}\nExtra info here.')
         with pytest.raises(ConstraintViolated) as exc_info:
             rephrased.check(['a', 'b'], ctx=fake_ctx)
         assert str(exc_info.value) == '__error__\nExtra info here.'


### PR DESCRIPTION
Rather than inserting these `format` fields as plain string (`{error}` and `{param_list}`), you can use `ErrorFmt`. It improves Cloup in two ways:
- you get auto-completion and don't risk a run-time error because of a typo
- `ErrorFmt` gives a natural home to docstrings for these replacement fields.

```python
from cloup.constraints import ErrorFmt

mutually_exclusive.rephrased(
    error=f"{ErrorFmt.error}.\nUse --renderer, the other two options are deprecated."
)
```

This PR also improves quite a bit the "Constraints" chapter of the docs. I'm pretty satisfied with it!