### PR TITLE
Improve type hints of command decorators, allow `cls` to be any `click.Group` in `@group`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,39 @@ Changelog
     Deprecated
     ----------
 
+v0.10.0 (in development)
+=======================
+
+New features and enhancements
+-----------------------------
+- Improvements to type hints of command decorators and other changes (:pr`67`):
+
+  - mypy can now infer the exact type of the instantiated command based on the
+    ``cls`` argument. (Unfortunately, this required the use of ``@overload`` to
+    work around a mypy limitation)
+  - in ``@group``, allow ``cls`` to be any ``click.Group`` (previously it had to
+    be a subclass of ``cloup.Group``)
+  - in ``Group.command`` and ``Group.group`` add type hints and make all arguments
+    except ``name`` keyword-only. Technically this is a (minor) incompatibility
+    with the ``click.Group`` superclass, but it's coherent with Cloup's
+    ``@command`` and ``@group``
+  - add Cloup-specific arguments to the signature of ``@command``; if the developer
+    uses one of such arguments with a ``cls`` that doesn't support them, Cloup
+    augments the resulting ``TypeError`` with extra information.
+
+Bug fixes
+-----------------------------
+
+Breaking changes
+----------------
+- In ``Group.command`` and ``Group.group`` add type hints and make all arguments
+  except ``name`` keyword-only.
+
+Deprecated
+----------
+
+--------------------------------------------------------------------------------
+
 v0.9.1 (2021-07-03)
 ===================
 - Fixed bug: Shell completion breaking because Cloup checks constraints despite

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,3 +1,5 @@
+import re
+
 import click
 import pytest
 
@@ -6,16 +8,28 @@ from cloup._util import reindent
 from tests.util import new_dummy_func
 
 
-def test_group_raises_if_cls_is_not_subclass_of_cloup_Group():
-    class GroupSubclass(cloup.Group):
-        pass
+def test_command_handling_of_unknown_argument():
+    with pytest.raises(TypeError, match='HINT: you set cls='):
+        cloup.command(cls=click.Command, align_option_groups=True)(new_dummy_func())
+    with pytest.raises(TypeError, match='nonexisting') as info:
+        cloup.command(nonexisting=True)(new_dummy_func())
+    assert re.search(str(info.value), 'HINT') is None
 
-    # Shouldn't raise with default arguments
-    cloup.group('ciao')
-    cloup.group(align_sections=True, cls=cloup.Group)
-    cloup.group(align_sections=True, cls=GroupSubclass)
+
+def test_group_raises_if_cls_is_not_subclass_of_click_Group():
+    cloup.group()
+    cloup.group(cls=click.Group)
+    cloup.group(cls=cloup.Group)
     with pytest.raises(TypeError):
-        cloup.group(cls=click.Group)
+        cloup.group(cls=click.Command)
+
+
+def test_group_handling_of_unknown_argument():
+    with pytest.raises(TypeError, match='HINT'):
+        cloup.group(cls=click.Group, align_sections=True)(new_dummy_func())
+    with pytest.raises(TypeError) as info:
+        cloup.group(unexisting_arg=True)(new_dummy_func())
+    assert re.search(str(info.value), 'HINT') is None
 
 
 def test_command_works_with_no_parameters(runner):


### PR DESCRIPTION

- Closes #7.

- In ``@group``, allow ``cls`` to be any ``click.Group`` (previously it had to
  be a subclass of ``cloup.Group``).

- In ``Group.command`` and ``Group.group`` add type hints and make all arguments
  except ``name`` keyword-only. Technically this is a (minor) incompatibility
  with the ``click.Group`` superclass, but it's coherent with Cloup's
  ``@command`` and ``@group``.

- Closes #63. 
  If the developer uses one of such arguments with a ``cls`` that doesn't support them, Cloup
  augments the resulting ``TypeError`` with extra information.  
