### PR TITLE
Feature: subcommand aliases

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -48,6 +48,10 @@ Breaking changes
 
 - The ``name`` parameter/attribute of ``OptionGroup`` was renamed to ``title``.
 
+- In ``SectionMixin`` (thus, in ``Group``), added a ``ctx: Context`` attribute
+  to make_commands_help_section and format_subcommand_name to support the
+  ``show_subcommand_aliases`` setting.
+
 --------------------------------------------------------------------------------
 
 v0.9.1 (2021-07-03)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ v0.10.0 (in development)
 
 New features and enhancements
 -----------------------------
+- New feature: subcommand aliases. :issue:`64` :pr:`75`
+
 - Command decorators: improvements to type hints and other changes (:pr:`67`):
 
   - mypy can now infer the exact type of the instantiated command based on the

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@
     <p align="center">
         <i>
             <a href="https://github.com/pallets/click">Click</a>
-            + option groups + constraints + themes + ...
+            + option groups + constraints + aliases + help themes + ...
         </i>
     </p>
 
@@ -63,14 +63,17 @@ more expressive and configurable:
 - **constraints**, like ``mutually_exclusive``, that can be applied to any group
   of parameters, even *conditionally*
 
-- **sections for subcommands**, i.e. the possibility to organize the subcommands of a
+- **subcommand aliases**
+
+- **subcommands sections**, i.e. the possibility to organize the subcommands of a
   ``Group`` in multiple help sections
 
 - a **themeable HelpFormatter**  that:
 
   - has more parameters for adjusting widths and spacing, which can be provided
     at the context and command level
-  - use a different layout when the terminal width is small, to improve readability.
+  - use a different layout when the terminal width is below a certain threshold
+    in order to improve readability.
 
 Moreover, Cloup improves on **IDE support** providing *detailed* type hints for
 Click decorators and adding the static methods ``Context.settings()`` and

--- a/cloup/_context.py
+++ b/cloup/_context.py
@@ -4,9 +4,9 @@ from typing import Any, Callable, Dict, List, Optional, Type
 import click
 
 import cloup
-from cloup._util import first_not_none, pick_non_missing
-from cloup.typing import MISSING, Possibly
+from cloup._util import coalesce, pick_non_missing
 from cloup.formatting import HelpFormatter
+from cloup.typing import MISSING, Possibly
 
 
 def _warn_if_formatter_settings_conflict(
@@ -45,6 +45,8 @@ class Context(click.Context):
         if True, align the definition lists of all subcommands of a group.
         You can override this by setting the corresponding argument of ``Group``
         (but you probably shouldn't: be consistent).
+    :param show_subcommand_aliases:
+        whether to show the aliases of subcommands in the help of a ``cloup.Group``.
     :param show_constraints:
         whether to include a "Constraint" section in the command help (if at
         least one constraint is defined).
@@ -66,21 +68,26 @@ class Context(click.Context):
         self, *ctx_args,
         align_option_groups: Optional[bool] = None,
         align_sections: Optional[bool] = None,
+        show_subcommand_aliases: Optional[bool] = None,
         show_constraints: Optional[bool] = None,
-        check_constraints_consistency: bool = True,
+        check_constraints_consistency: bool = True,  # TODO: fix this
         formatter_settings: Dict[str, Any] = {},
         **ctx_kwargs,
     ):
         super().__init__(*ctx_args, **ctx_kwargs)
-        self.align_option_groups = first_not_none(
+        self.align_option_groups = coalesce(
             align_option_groups,
             getattr(self.parent, 'align_option_groups', None),
         )
-        self.align_sections = first_not_none(
+        self.align_sections = coalesce(
             align_sections,
             getattr(self.parent, 'align_sections', None),
         )
-        self.show_constraints = first_not_none(
+        self.show_subcommand_aliases = coalesce(
+            show_subcommand_aliases,
+            getattr(self.parent, 'show_subcommand_aliases', None),
+        )
+        self.show_constraints = coalesce(
             show_constraints,
             getattr(self.parent, 'show_constraints', None),
         )
@@ -129,6 +136,7 @@ class Context(click.Context):
         show_default: Possibly[bool] = MISSING,
         align_option_groups: Possibly[bool] = MISSING,
         align_sections: Possibly[bool] = MISSING,
+        show_subcommand_aliases: Possibly[bool] = MISSING,
         show_constraints: Possibly[bool] = MISSING,
         check_constraints_consistency: Possibly[bool] = MISSING,
         formatter_settings: Possibly[Dict[str, Any]] = MISSING,
@@ -191,6 +199,8 @@ class Context(click.Context):
             if True, align the definition lists of all subcommands of a group.
             You can override this by setting the corresponding argument of ``Group``
             (but you probably shouldn't: be consistent).
+        :param show_subcommand_aliases:
+            whether to show the aliases of subcommands in the help of a ``cloup.Group``.
         :param show_constraints:
             whether to include a "Constraint" section in the command help (if at
             least one constraint is defined).

--- a/cloup/_sections.py
+++ b/cloup/_sections.py
@@ -199,24 +199,27 @@ class SectionMixin:
             section_list.append(default_section)
         return section_list
 
-    def format_subcommand_name(self, name: str, cmd: click.Command) -> str:
-        """Used to format the name of the subcommands. This method turns useful
-        when you combine this extension to other click extensions that override
-        :meth:`format_commands`. Most of these, like click-default-group and
-        click-aliases, just add something to the name of the subcommands, which
-        is exactly what this method allows you to do without overriding bigger
-        methods.
+    def format_subcommand_name(
+        self, ctx: click.Context, name: str, cmd: click.Command
+    ) -> str:
+        """Used to format the name of the subcommands. This method is useful
+        when you combine this extension with other click extensions that override
+        :meth:`format_commands`. Most of these, like click-default-group, just
+        add something to the name of the subcommands, which is exactly what this
+        method allows you to do without overriding bigger methods.
         """
         return name
 
-    def make_commands_help_section(self, section: Section) -> Optional[HelpSection]:
+    def make_commands_help_section(
+        self, ctx: click.Context, section: Section
+    ) -> Optional[HelpSection]:
         visible_subcommands = section.list_commands()
         if not visible_subcommands:
             return None
         return HelpSection(
             heading=section.title,
             definitions=[
-                (self.format_subcommand_name(name, cmd), cmd.get_short_help_str)
+                (self.format_subcommand_name(ctx, name, cmd), cmd.get_short_help_str)
                 for name, cmd in visible_subcommands
             ]
         )
@@ -235,7 +238,7 @@ class SectionMixin:
 
         subcommand_sections = self.list_sections(ctx)
         help_sections = pick_not_none(
-            self.make_commands_help_section(section)
+            self.make_commands_help_section(ctx, section)
             for section in subcommand_sections
         )
         if not help_sections:

--- a/cloup/_util.py
+++ b/cloup/_util.py
@@ -79,13 +79,12 @@ def pluralize(
     return many.format(count=count)
 
 
-def first_not_none(*values: Optional[T]) -> Optional[T]:
-    """Returns the first value that is not None
-    (or ``default`` if no such value exists)."""
+def coalesce(*values: Optional[T]) -> Optional[T]:
+    """Returns the first value that is not None (or None if no such value exists)."""
     return next((val for val in values if val is not None), None)
 
 
-def first_bool(*values: Optional[bool]) -> bool:
+def first_bool(*values: Any) -> bool:
     """Returns the first bool (or raises StopIteration if no bool is found)."""
     return next(val for val in values if isinstance(val, bool))
 

--- a/cloup/formatting/_formatter.py
+++ b/cloup/formatting/_formatter.py
@@ -172,6 +172,11 @@ class HelpFormatter(click.HelpFormatter):
         prog = self.theme.invoked_command(prog)
         super().write_usage(prog, args, prefix)
 
+    def write_aliases(self, aliases: Sequence[str]) -> None:
+        self.write_heading("Aliases", newline=False)
+        alias_list = ", ".join(self.theme.col1(alias) for alias in aliases)
+        self.write(f" {alias_list}\n")
+
     def write_command_help_text(self, cmd: click.Command) -> None:
         help_text = cmd.help or ''
         if cmd.deprecated:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,7 @@ Please, note that Cloup documentation doesn't replace
     pages/installation
     pages/option-groups
     pages/constraints
+    pages/aliases
     pages/sections
     pages/formatting
 

--- a/docs/pages/aliases.rst
+++ b/docs/pages/aliases.rst
@@ -1,0 +1,92 @@
+Subcommand aliases
+==================
+
+Aliases are alternative names for subcommands. They are often used to
+define "shortcuts", e.g. ``i`` for ``install``.
+
+Usage
+-----
+The usage of this feature is pretty straightforward: just use the ``aliases``
+parameter exposed by Cloup command decorators.
+
+.. code-block:: python
+    :emphasize-lines: 6,13
+
+    @cloup.group(show_subcommand_aliases=True)
+    def cli():
+        """A package installer."""
+        pass
+
+    @cli.command(aliases=['i', 'add'])
+    @cloup.argument('pkg')
+    def install(pkg: str):
+        """Install a package."""
+        print('install', pkg)
+
+    # Aliases works even if cls is not a Cloup command class
+    @cli.command(aliases=['uni', 'rm'], cls=click.Command)
+    @cloup.argument('pkg')
+    def uninstall(pgk: str):
+        """Uninstall a package."""
+        print('uninstall', pkg)
+
+.. note::
+    It's worth noting that the ``aliases`` argument is exposed  by *all* command
+    decorators, not just ``Group.command`` and ``Group.group`` (used in the
+    example above). This is possible because aliases are stored in the subcommand,
+    so a ``Group`` can get them from the added command itself.
+
+
+Help output of the group
+------------------------
+
+By default, aliases are **not** shown in the "Commands" section(s) of the ``Group``.
+If you want to show them, you can set ``show_subcommand_aliases=True`` as in the
+example above. This argument is also available as a context setting.
+With ``show_subcommand_aliases=True`` the ``--help`` output is:
+
+.. code-block:: none
+    :emphasize-lines: 9-10
+
+    Usage: cli [OPTIONS] COMMAND [ARGS]...
+
+      A package installer.
+
+    Options:
+      --help  Show this message and exit.
+
+    Commands:
+      install (i, add)     Install a package.
+      uninstall (uni, rm)  Uninstall a package.
+
+.. admonition:: Customizing the format of the first column
+    :class: note
+
+    If you ever feel the need, you can easily customize the format of the first
+    column overriding the method :meth:`Group.format_subcommand_name`.
+    My suggestion is to copy the default implementation and modify it.
+
+
+Help output of the subcommand
+-----------------------------
+
+.. attention::
+    Aliases are shown **only** in the ``--help`` output of subcommands that
+    extends ``cloup.BaseCommand``. So, normal ``click.Command`` won't do it.
+
+.. code-block:: text
+    :emphasize-lines: 2
+
+    Usage: cli install [OPTIONS] PKG
+    Aliases: i, add
+
+      Install a package.
+
+    Options:
+      --help  Show this message and exit.
+
+This is possible because aliases are stored in the subcommand itself, precisely
+in the ``aliases`` attribute. Cloup commands declare this attribute and accept
+it as a parameter. For all other type of commands, Cloup uses monkey-patching
+to add this attribute.
+

--- a/examples/manim/config.py
+++ b/examples/manim/config.py
@@ -4,13 +4,17 @@ import click
 import cloup
 
 
-@cloup.group(invoke_without_command=True, no_args_is_help=True)
-def cfg():
+@cloup.group(
+    'config', aliases=['conf', 'cfg'],
+    invoke_without_command=True,
+    no_args_is_help=True,
+)
+def config():
     """Manages Manim configuration files."""
     pass
 
 
-@cfg.command(no_args_is_help=True)
+@config.command(no_args_is_help=True)
 @click.option(
     "-l", "--level",
     type=click.Choice(["user", "cwd"], case_sensitive=False), default="cwd",
@@ -22,13 +26,13 @@ def write(level: str, openfile: bool) -> None:
     pass
 
 
-@cfg.command()
+@config.command()
 def show():
     """Shows current configuration."""
     pass
 
 
-@cfg.command()
+@config.command()
 @click.option("-d", "--directory", default=os.getcwd())
 def export(directory):
     pass

--- a/examples/manim/main.py
+++ b/examples/manim/main.py
@@ -12,7 +12,7 @@ from cloup import (
     Style,
 )
 from cloup.formatting.sep import RowSepIf, multiline_rows_are_at_least
-from config import cfg
+from config import config
 from render import render
 
 VERSION = '0.5.0'
@@ -58,7 +58,7 @@ def main():
 
 
 main.add_command(render)
-main.add_command(cfg)
+main.add_command(config)
 
 if __name__ == "__main__":
     main(prog_name='manim')

--- a/examples/manim/render.py
+++ b/examples/manim/render.py
@@ -7,7 +7,7 @@ from cloup import argument, option, option_group
 from cloup.constraints import ErrorFmt, mutually_exclusive
 
 
-@cloup.command()
+@cloup.command(aliases=["r", "re"])
 @argument("script_path", type=click.Path(), required=True)
 @argument("scene_names", required=False, nargs=-1)
 @option_group(

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -1,0 +1,171 @@
+import click
+import pytest
+
+import cloup
+from cloup import Group
+from cloup._util import first_bool, reindent
+from cloup.typing import MISSING
+
+
+@pytest.fixture()
+def cli() -> cloup.Group:
+    @cloup.group()
+    def cli():
+        """A package installer."""
+        pass
+
+    @cloup.command(aliases=['i', 'add'])
+    @cloup.argument('pkg')
+    def install(pkg: str):
+        """Install a package."""
+        print('install', pkg)
+
+    @cloup.group(aliases=['conf', 'cfg'])
+    def config():
+        """Manage the configuration."""
+        print('config')
+
+    @cloup.command(aliases=['clr'], cls=click.Command)
+    def clear():
+        """Remove all installed packages."""
+        print('clear')
+
+    cli.section('Commands', install, clear, config)
+    return cli
+
+
+cli_help_without_aliases = reindent("""
+    Usage: cli [OPTIONS] COMMAND [ARGS]...
+
+      A package installer.
+
+    Options:
+      --help  Show this message and exit.
+
+    Commands:
+      install  Install a package.
+      clear    Remove all installed packages.
+      config   Manage the configuration.
+""")
+
+cli_help_with_aliases = reindent("""
+    Usage: cli [OPTIONS] COMMAND [ARGS]...
+
+      A package installer.
+
+    Options:
+      --help  Show this message and exit.
+
+    Commands:
+      install (i, add)    Install a package.
+      clear (clr)         Remove all installed packages.
+      config (conf, cfg)  Manage the configuration.
+""")
+
+
+def test_command_aliases_are_stored_in_the_command(cli):
+    assert cli.commands['install'].aliases == ['i', 'add']
+    assert cli.commands['clear'].aliases == ['clr']
+
+
+def test_simple_command_name_resolution(cli):
+    ctx = cloup.Context(command=cli)
+    assert cli.resolve_command_name(ctx, 'install') == 'install'
+    assert cli.resolve_command_name(ctx, 'i') == 'install'
+    assert cli.resolve_command_name(ctx, 'add') == 'install'
+
+    assert cli.resolve_command_name(ctx, 'config') == 'config'
+    assert cli.resolve_command_name(ctx, 'conf') == 'config'
+
+    assert cli.resolve_command_name(ctx, 'clear') == 'clear'
+    assert cli.resolve_command_name(ctx, 'clr') == 'clear'
+
+
+def test_command_name_resolution_with_token_normalization_function(cli):
+    ctx = cloup.Context(command=cli, token_normalize_func=str.lower)
+    assert cli.resolve_command_name(ctx, 'INSTALL') == 'install'
+    assert cli.resolve_command_name(ctx, 'ADD') == 'install'
+    assert cli.resolve_command_name(ctx, 'CLR') == 'clear'
+    assert cli.resolve_command_name(ctx, 'cONF') == 'config'
+
+
+@pytest.mark.parametrize('alias', ['install', 'i', 'add'])
+def test_command_resolution_with_cloup_subcommand(cli, runner, alias):
+    res = runner.invoke(cli, [alias, 'cloup'])
+    assert res.output.strip() == 'install cloup'
+
+
+@pytest.mark.parametrize('alias', ['clear', 'clr'])
+def test_command_resolution_with_click_subcommand(cli, runner, alias):
+    res = runner.invoke(cli, [alias])
+    assert res.output.strip() == 'clear'
+
+
+@pytest.mark.parametrize(
+    'cmd_value', [MISSING, None, True, False],
+    ids=lambda val: f'cmd_{val}'
+)
+@pytest.mark.parametrize(
+    'ctx_value', [MISSING, None, True, False],
+    ids=lambda val: f'ctx_{val}'
+)
+def test_show_subcommand_aliases_setting(cli, runner, ctx_value, cmd_value):
+    if ctx_value is not MISSING:
+        cli.context_settings['show_subcommand_aliases'] = ctx_value
+    if cmd_value is not MISSING:
+        cli.show_subcommand_aliases = cmd_value
+
+    should_show_aliases = first_bool(cmd_value, ctx_value, Group.SHOW_SUBCOMMAND_ALIASES)
+    expected_help = (cli_help_with_aliases
+                     if should_show_aliases
+                     else cli_help_without_aliases)
+
+    res = runner.invoke(cli, ['--help'])
+    assert res.output == expected_help
+
+
+def test_cloup_subcommand_help(cli, runner):
+    res = runner.invoke(cli, ['i', '--help'])
+    # 1. Shows the full subcommand name even if an alias was used.
+    # 2. Shows aliases after help text.
+    expected = reindent("""
+        Usage: cli install [OPTIONS] PKG
+        Aliases: i, add
+
+          Install a package.
+
+        Options:
+          --help  Show this message and exit.
+    """)
+    assert res.output == expected
+
+
+def test_click_subcommand_help(cli, runner):
+    res = runner.invoke(cli, ['clr', '--help'])
+    # Shows the full subcommand name even if an alias was used.
+    # Aliases are not shown (need Cloup commands for that).
+    expected = reindent("""
+        Usage: cli clear [OPTIONS]
+
+          Remove all installed packages.
+
+        Options:
+          --help  Show this message and exit.
+    """)
+    assert res.output == expected
+
+
+def test_cloup_subgroup_help(cli, runner):
+    res = runner.invoke(cli, ['conf', '--help'])
+    # 1. Shows the full subcommand name even if an alias was used.
+    # 2. Shows aliases after help text.
+    expected = reindent("""
+        Usage: cli config [OPTIONS] COMMAND [ARGS]...
+        Aliases: conf, cfg
+
+          Manage the configuration.
+
+        Options:
+          --help  Show this message and exit.
+    """)
+    assert res.output == expected

--- a/tests/test_sections.py
+++ b/tests/test_sections.py
@@ -116,7 +116,7 @@ def test_align_sections_context_setting(runner, ctx_value, cmd_value):
 
 def test_override_format_subcommand_name(runner):
     class MyGroup(cloup.Group):
-        def format_subcommand_name(self, name: str, cmd: click.Command) -> str:
+        def format_subcommand_name(self, ctx, name, cmd) -> str:
             return '*special*' if name == 'special' else name
 
     main = MyGroup(name='main')

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,6 @@
 import pytest
 
-from cloup._util import check_positive_int, make_repr
+from cloup._util import check_positive_int, coalesce, first_bool, make_repr
 
 
 def test_make_repr():
@@ -29,3 +29,17 @@ def test_check_positive_int():
         check_positive_int(None, 'name')
     with pytest.raises(TypeError):
         check_positive_int(1.23, 'name')
+
+
+def test_first_bool():
+    assert first_bool(0, 1, None, '', [], False, True) is False
+    assert first_bool(0, 1, None, '', [], True, False) is True
+    with pytest.raises(StopIteration):
+        first_bool(1, 2, '', [], None)
+
+
+def test_coalesce():
+    assert coalesce() is None
+    assert coalesce(None, None, None) is None
+    for expected in [0, '', [], False, 123]:
+        assert coalesce(None, None, expected, True, 12) == expected


### PR DESCRIPTION
Changes:
- Closes #64.
- Add an ``aliases`` attribute to Cloup commands and decorators.
- Decorators add ``aliases`` to non-Cloup commands by monkey-patching (if provided).
- Cloup commands always show aliases in their own help, below Usage.
- Add a ``show_subcommand_aliases`` setting to `cloup.Group` and `Context`. This option is for showing aliases of subcommand in the `Group` help output and defaults to `False`.
- To support the ``show_subcommand_aliases`` context setting, added `ctx` argument to `make_commands_help_section` and `format_subcommand_name`.

See the docs for more.
