### PR TITLE
Fixed example in documentation and removed duplicate parameter info

### DIFF
--- a/cloup/_commands.py
+++ b/cloup/_commands.py
@@ -577,10 +577,6 @@ def group(name=None, *, cls=None, **kwargs):
     :param add_help_option:
         by default each command registers a ``--help`` option.
         This can be disabled by this parameter.
-    :param no_args_is_help:
-        this controls what happens if no arguments are provided. This option is
-        disabled by default. If enabled this will add ``--help`` as argument if
-        no arguments are passed
     :param hidden:
         hide this command from help outputs.
     :param deprecated:

--- a/docs/pages/formatting.rst
+++ b/docs/pages/formatting.rst
@@ -50,8 +50,8 @@ An example
         # parameters of HelpFormatter:
         formatter_settings=HelpFormatter.settings(
             max_width=100,
-            max_col1_width=25,
-            min_col2_width=30,
+            col1_max_width=25,
+            col2_min_width=30,
             indent_increment=3,
             col_spacing=3,
             row_sep='',  # empty line between definitions
@@ -69,7 +69,7 @@ An example
     @main.command(
         align_option_groups=True,  # overrides the context setting
         formatter_settings=HelpFormatter.settings(
-            max_col1_width=30,  # overrides this specific formatter parameter
+            col1_max_width=30,  # overrides this specific formatter parameter
         )
     )
     # ...
@@ -371,11 +371,11 @@ The following tabs compare the ``--help`` of the manim example ("aligned" and
 
 
 The linear layout is used when the available width for the 2nd column is below
-``min_col2_width``, one of the ``formatter_settings``.
+``col2_min_width``, one of the ``formatter_settings``.
 
-You can disable the linear layout settings ``min_col2_width=0``.
+You can disable the linear layout settings ``col2_min_width=0``.
 
-You make the linear layout your default layout by settings ``min_col2_width`` to
+You make the linear layout your default layout by settings ``col2_min_width`` to
 a large number, possibly ``math.inf``.
 
 

--- a/docs/pages/option-groups.rst
+++ b/docs/pages/option-groups.rst
@@ -193,7 +193,7 @@ Since v0.8.0, this parameter is also available as a ``Context`` setting::
 
 .. note::
     The problem of aligned groups can sometimes be solved decreasing the
-    :class:`HelpFormatter` parameter ``max_col1_width``, which defaults to 30.
+    :class:`HelpFormatter` parameter ``col1_max_width``, which defaults to 30.
 
 
 Alternative APIs


### PR DESCRIPTION
I was implementing [HelpFormatter/Themes in Manim](https://github.com/ManimCommunity/manim/pull/1975) and when referencing the documentation I noticed some small issues.

I do think there is the potential to use sphinx.ext.doctest if you're interested in testing your code snippets in the documentation in the future.