### PR TITLE
Integrate sphinx.ext.doctest for a few example snippets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,11 @@ versions of Python (>=3.6) and Click (>=7.2).
 A simple example
 ================
 
-.. code-block:: python
+.. testsetup::
+
+    __name__ = "__main__"
+
+.. testcode::
 
     from cloup import (
         HelpFormatter, HelpTheme, Style,
@@ -124,9 +128,28 @@ A simple example
         """This is the command description."""
         pass
 
-    if __name__ == '__main__':
-        cmd(prog_name='invoked-command')
+    if __name__ == "__main__":
+        cmd(["--help"], prog_name='invoked-command', standalone_mode=False)
 
+.. testoutput::
+    :hide:
+    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+
+    Usage: invoked-command [OPTIONS]
+
+      This is the command description.
+
+    Cool options: [mutually exclusive]
+      --foo TEXT    This text should describe the option --foo.
+      --bar TEXT    This text should describe the option --bar.
+
+    Other cool options: [at least 1 required]
+      This is the optional description of this option group.
+      --pippo TEXT  This text should describe the option --pippo.
+      --pluto TEXT  This text should describe the option --pluto.
+
+    Other options:
+      --help        Show this message and exit.
 
 .. image:: https://raw.githubusercontent.com/janLuke/cloup/master/docs/_static/basic-example.png
     :alt: Basic example --help screenshot

--- a/README.rst
+++ b/README.rst
@@ -86,11 +86,9 @@ versions of Python (>=3.6) and Click (>=7.2).
 A simple example
 ================
 
-.. testsetup::
+.. docs-index-code-start
 
-    __name__ = "__main__"
-
-.. testcode::
+.. code-block:: python
 
     from cloup import (
         HelpFormatter, HelpTheme, Style,
@@ -128,28 +126,10 @@ A simple example
         """This is the command description."""
         pass
 
-    if __name__ == "__main__":
-        cmd(["--help"], prog_name='invoked-command', standalone_mode=False)
+    if __name__ == '__main__':
+        cmd(prog_name='invoked-command')
 
-.. testoutput::
-    :hide:
-    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
-
-    Usage: invoked-command [OPTIONS]
-
-      This is the command description.
-
-    Cool options: [mutually exclusive]
-      --foo TEXT    This text should describe the option --foo.
-      --bar TEXT    This text should describe the option --bar.
-
-    Other cool options: [at least 1 required]
-      This is the optional description of this option group.
-      --pippo TEXT  This text should describe the option --pippo.
-      --pluto TEXT  This text should describe the option --pluto.
-
-    Other options:
-      --help        Show this message and exit.
+.. docs-index-code-end
 
 .. image:: https://raw.githubusercontent.com/janLuke/cloup/master/docs/_static/basic-example.png
     :alt: Basic example --help screenshot

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,6 +11,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autodoc.typehints',
     'autoapi.extension',
+    'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
     'sphinx.ext.viewcode',
     'sphinx_panels',
@@ -18,6 +19,10 @@ extensions = [
     'versionwarning.extension',
     'sphinx_issues',  # link to GitHub issues and PRs
 ]
+doctest_global_setup = '''
+from cloup import *
+from cloup.constraints import *
+'''
 
 # General information about the project.
 project = 'cloup'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,8 +13,76 @@
 
 .. include:: ../README.rst
     :start-after: docs-index-start
-    :end-before: docs-index-end
+    :end-before: docs-index-code-start
 
+.. testsetup::
+
+    __name__ = "__main__"
+
+.. testcode::
+
+    from cloup import (
+        HelpFormatter, HelpTheme, Style,
+        command, option, option_group
+    )
+    from cloup.constraints import RequireAtLeast, mutually_exclusive
+
+    # Check the docs for all available arguments of HelpFormatter and HelpTheme.
+    formatter_settings = HelpFormatter.settings(
+        theme=HelpTheme(
+            invoked_command=Style(fg='bright_yellow'),
+            heading=Style(fg='bright_white', bold=True),
+            constraint=Style(fg='magenta'),
+            col1=Style(fg='bright_yellow'),
+        )
+    )
+
+    # In a multi-command app, you can pass formatter_settings as part
+    # of your context_settings so that they are propagated to subcommands.
+    @command(formatter_settings=formatter_settings)
+    @option_group(
+        "Cool options",
+        option('--foo', help='This text should describe the option --foo.'),
+        option('--bar', help='This text should describe the option --bar.'),
+        constraint=mutually_exclusive,
+    )
+    @option_group(
+        "Other cool options",
+        "This is the optional description of this option group.",
+        option('--pippo', help='This text should describe the option --pippo.'),
+        option('--pluto', help='This text should describe the option --pluto.'),
+        constraint=RequireAtLeast(1),
+    )
+    def cmd(**kwargs):
+        """This is the command description."""
+        pass
+
+    if __name__ == "__main__":
+        cmd(["--help"], prog_name='invoked-command', standalone_mode=False)
+
+.. testoutput::
+    :hide:
+    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+
+    Usage: invoked-command [OPTIONS]
+
+    This is the command description.
+
+    Cool options: [mutually exclusive]
+    --foo TEXT    This text should describe the option --foo.
+    --bar TEXT    This text should describe the option --bar.
+
+    Other cool options: [at least 1 required]
+    This is the optional description of this option group.
+    --pippo TEXT  This text should describe the option --pippo.
+    --pluto TEXT  This text should describe the option --pluto.
+
+    Other options:
+        --help        Show this message and exit.
+
+.. include:: ../README.rst
+    :start-after: docs-index-code-end
+    :end-before: docs-index-end
 
 User guide
 ==========

--- a/docs/pages/constraints.rst
+++ b/docs/pages/constraints.rst
@@ -480,38 +480,46 @@ Example 2: defining a new parametric constraint
 
 *Option 1 -- Just use a function.*
 
-.. code-block:: python
+.. testcode::
+    :pyversion: >= 3.6
 
-    >>> import cloup
-    >>> def accept_between(min, max):
-    ...    return (cloup.constraints.RequireAtLeast(min) & cloup.constraints.AcceptAtMost(max)).rephrased(
-    ...        help=f'at least {min} required, at most {max} accepted'
-    ...    )
+    def accept_between(min, max):
+       return (RequireAtLeast(min) & AcceptAtMost(max)).rephrased(
+           help=f'at least {min} required, at most {max} accepted'
+       )
 
-    >>> accept_between(1, 3)
+    print(accept_between(1, 3))
+
+.. testoutput::
+
     Rephraser(help='at least 1 required, at most 3 accepted')
 
 *Option 2 -- WrapperConstraint.* This is useful when you want to define a new
 constraint type. ``WrapperConstraint`` delegates all methods to the wrapped
 constraint so you can override only the methods you need to override.
 
-.. doctest:: python
+.. testcode::
     :pyversion: >= 3.6
 
-    >>> class AcceptBetween(WrapperConstraint):
-    ...    def __init__(self, min: int, max: int):
-    ...        # [...]
-    ...        self._min = min
-    ...        self._max = max
-    ...        # whatever you pass as **kwargs is used in the __repr__
-    ...        super().__init__(
-    ...            RequireAtLeast(min) & AcceptAtMost(max),
-    ...            min=min, max=max,  # <= included in the __repr__
-    ...        )
-    ...    def help(self, ctx: Context) -> str:
-    ...        return f'at least {self._min} required, at most {self._max} accepted'
+    class AcceptBetween(WrapperConstraint):
+        def __init__(self, min: int, max: int):
+            # [...]
+            self._min = min
+            self._max = max
+            # whatever you pass as **kwargs is used in the __repr__
+            super().__init__(
+                RequireAtLeast(min) & AcceptAtMost(max),
+                min=min, max=max,  # <= included in the __repr__
+            )
 
-    >>> AcceptBetween(1, 3)
+        def help(self, ctx: Context) -> str:
+            return f'at least {self._min} required, ' \
+                   f'at most {self._max} accepted'
+
+    print(AcceptBetween(1, 3))
+
+.. testoutput::
+
     AcceptBetween(min=1, max=3)
 
 

--- a/docs/pages/constraints.rst
+++ b/docs/pages/constraints.rst
@@ -482,10 +482,11 @@ Example 2: defining a new parametric constraint
 
 .. code-block:: python
 
-    def accept_between(min, max):
-       return (RequireAtLeast(min) & AcceptAtMost(max)).rephrased(
-           help=f'at least {min} required, at most {max} accepted'
-       )
+    >>> import cloup
+    >>> def accept_between(min, max):
+    ...    return (cloup.constraints.RequireAtLeast(min) & cloup.constraints.AcceptAtMost(max)).rephrased(
+    ...        help=f'at least {min} required, at most {max} accepted'
+    ...    )
 
     >>> accept_between(1, 3)
     Rephraser(help='at least 1 required, at most 3 accepted')
@@ -494,26 +495,24 @@ Example 2: defining a new parametric constraint
 constraint type. ``WrapperConstraint`` delegates all methods to the wrapped
 constraint so you can override only the methods you need to override.
 
-.. code-block:: python
+.. doctest:: python
+    :pyversion: >= 3.6
 
-    class AcceptBetween(WrapperConstraint):
-        def __init__(self, min: int, max: int):
-            # [...]
-            self._min = min
-            self._max = max
-            # whatever you pass as **kwargs is used in the __repr__
-            super().__init__(
-                RequireAtLeast(min) & AcceptAtMost(max),
-                min=min, max=max,  # <= included in the __repr__
-            )
-
-        def help(self, ctx: Context) -> str:
-            return f'at least {self._min} required, ' \
-                   f'at most {self._max} accepted'
-
+    >>> class AcceptBetween(WrapperConstraint):
+    ...    def __init__(self, min: int, max: int):
+    ...        # [...]
+    ...        self._min = min
+    ...        self._max = max
+    ...        # whatever you pass as **kwargs is used in the __repr__
+    ...        super().__init__(
+    ...            RequireAtLeast(min) & AcceptAtMost(max),
+    ...            min=min, max=max,  # <= included in the __repr__
+    ...        )
+    ...    def help(self, ctx: Context) -> str:
+    ...        return f'at least {self._min} required, at most {self._max} accepted'
 
     >>> AcceptBetween(1, 3)
-    AcceptBetween(1, 3)
+    AcceptBetween(min=1, max=3)
 
 
 \*Validation protocol

--- a/tox.ini
+++ b/tox.ini
@@ -58,6 +58,7 @@ commands = python --version
 basepython = python3.8
 deps = -r requirements/docs.txt
 commands =
+  python -msphinx -b doctest docs docs/_build/doctest
   python scripts/remove.py docs/_build
   sphinx-build {posargs:-E} -b html docs docs/_build/html
   sphinx-build -b linkcheck docs docs/_build/html


### PR DESCRIPTION
Closes #90 
Notably this adds three doctests. One for Option 1/2 in defining a parametric constraints and the simple example given in the README.rst.

I can add more doctests to this PR if you'd like to provide me a list of other examples in the docs to convert, or feel free to edit this PR/add more at a later date. The only constraint is that they have to be working snippets in the interpreter (no psuedocode/ellipsis/etc.).

Also changed in this PR is that `tox -e docs` runs the doctests first.