### PR TITLE
Feat: "did you mean <command>?" when a command is mistyped

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,12 @@ Changelog
     Deprecated
     ----------
 
+v0.12.0 (in development)
+========================
+- Feature: when a subcommand is mistyped, show "did you mean <subcommand>?".
+- Doc fixes.
+
+--------------------------------------------------------------------------------
 
 v0.11.0 (2021-08-05)
 ====================

--- a/CREDITS.rst
+++ b/CREDITS.rst
@@ -6,6 +6,10 @@ Author
 ------
 * Gianluca Gippetto <gianluca.gippetto@gmail.com>
 
+Contributors
+------------
+See https://github.com/janluke/cloup/graphs/contributors.
+
 Credits
 -------
 

--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,9 @@ more expressive and configurable:
   - has more parameters for adjusting widths and spacing, which can be provided
     at the context and command level
   - use a different layout when the terminal width is below a certain threshold
-    in order to improve readability.
+    in order to improve readability
+
+- suggestions like "did you mean <subcommand>?" when you mistype a subcommand.
 
 Moreover, Cloup improves on **IDE support** providing decorators with *detailed*
 type hints and adding the static methods ``Context.settings()`` and


### PR DESCRIPTION
The logic can be overridden overwriting the `Group.handle_bad_command_name` method.

Closes #93.