### PR TITLE
Feature: "Positional arguments" section. Make Group inherit from Command.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,9 @@ Breaking changes
   ``format_options`` did: that's what Click does and Cloup (reluctantly) did.
   Now, instead, ``cloup.Command`` calls ``format_params`` in ``format_help`` and
   then, for multi-commands, calls ``format_commands`` directly.
+- ``ConstraintMixin.format_help`` was removed. This means you can't just mix it
+  with a click.Command to make it print the "Constraints" help section, you need
+  to call ``format_constraints`` explicitly in your command ``format_help``.
 
 Deprecated
 ----------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,7 @@ New features and enhancements
 
 Breaking changes
 ----------------
-- ``BaseCommand`` was removed. This shouldn't case any issue to anybody.
+- ``BaseCommand`` was removed. This shouldn't cause any issue to anybody.
 - ``cloup.Group`` extends ``cloup.Command``, similarly as ``click.Group``
   extends ``click.Command``.
 - ``OptionGroupMixin.format_options`` was renamed to ``format_params``. This

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,26 @@ Changelog
     Deprecated
     ----------
 
+v0.14.0 (in development)
+========================
+New features and enhancements
+-----------------------------
+- You can show a "Positional arguments" help section by passing a non-empty
+  ``help`` description for at least one of the arguments of a command/group.
+- ``cloup.Group`` now extends ``cloup.Command`` and, as a consequence, supports
+  option groups and constraints.
+
+Breaking changes
+----------------
+- ``BaseCommand`` was removed. This shouldn't case any issue to anybody.
+- ``cloup.Group`` extends ``cloup.Command``, similarly as ``click.Group``
+  extends ``click.Command``.
+
+Deprecated
+----------
+
+--------------------------------------------------------------------------------
+
 v0.13.1 (2022-05-08)
 ====================
 - Since version 8.1.0, Click does not normalize the command attributes ``help``,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,13 @@ Breaking changes
 - ``BaseCommand`` was removed. This shouldn't case any issue to anybody.
 - ``cloup.Group`` extends ``cloup.Command``, similarly as ``click.Group``
   extends ``click.Command``.
+- ``OptionGroupMixin.format_options`` was renamed to ``format_params``. This
+  means you can't just mix it with ``click.Command`` to print help sections for
+  option groups, you have to override ``format_help`` and call ``format_params``.
+- The new ``format_params`` doesn't call ``super().format_commands`` as
+  ``format_options`` did: that's what Click does and Cloup (reluctantly) did.
+  Now, instead, ``cloup.Command`` calls ``format_params`` in ``format_help`` and
+  then, for multi-commands, calls ``format_commands`` directly.
 
 Deprecated
 ----------

--- a/README.rst
+++ b/README.rst
@@ -58,10 +58,10 @@ Overview
 `Click <https://github.com/pallets/click>`_ with several features that make it
 more expressive and configurable:
 
-- **option groups**
+- **option groups** and an (optional) help section for positional arguments
 
-- **constraints**, like ``mutually_exclusive``, that can be applied to any group
-  of parameters, even *conditionally*
+- **constraints**, like ``mutually_exclusive``, that can be applied to option groups
+  or to any group of parameters, even *conditionally*
 
 - **subcommand aliases**
 
@@ -143,6 +143,9 @@ If you don't provide ``--pippo`` or ``--pluto``:
     Error: at least 1 of the following parameters must be set:
       --pippo
       --pluto
+
+This simple example just scratches the surface. Read more in the documentation
+(links below).
 
 
 Supporting the project

--- a/cloup/__init__.py
+++ b/cloup/__init__.py
@@ -55,7 +55,6 @@ from ._sections import (
     SectionMixin,
 )
 from ._commands import (
-    BaseCommand,
     Command,
     Group,
     command,

--- a/cloup/__init__.py
+++ b/cloup/__init__.py
@@ -44,7 +44,7 @@ from .formatting import (
     HelpSection,
 )
 from ._context import Context
-from ._params import GroupedOption, argument, option
+from ._params import Argument, GroupedOption, argument, option
 from ._option_groups import (
     OptionGroup,
     OptionGroupMixin,

--- a/cloup/_commands.py
+++ b/cloup/_commands.py
@@ -674,8 +674,7 @@ def _process_unexpected_kwarg_error(
     arg = match.group()
     info = args_info[arg]
     extra_info = reindent(f"""\n
-        HINT: you set cls={cls} but this class
-        doesn't support the argument "{arg}".
+        HINT: you set cls={cls} but this class doesn't support the argument "{arg}".
         In Cloup, this argument is supported by {info.supported_by}
         via {info.requires.__name__}.
     """, 4)

--- a/cloup/_commands.py
+++ b/cloup/_commands.py
@@ -48,7 +48,7 @@ class Command(ConstraintMixin, OptionGroupMixin, click.Command):
 
     - :class:`ConstraintMixin`
     - :class:`OptionGroupMixin`
-    - :class:`BaseCommand` -> :class:`click.Command`
+    - :class:`click.Command`
 
     Besides other things, this class also:
 
@@ -127,7 +127,7 @@ class Group(SectionMixin, Command, click.Group):
     Refer to superclasses for the documentation of all accepted parameters:
 
     - :class:`SectionMixin`
-    - :class:`BaseCommand` -> :class:`click.Command`
+    - :class:`Command`
     - :class:`click.Group`
 
     Apart from superclasses arguments, the following is the only additional parameter:

--- a/cloup/_commands.py
+++ b/cloup/_commands.py
@@ -31,6 +31,7 @@ from typing import (
 import click
 from click import HelpFormatter
 
+import cloup
 from ._context import Context
 from ._option_groups import OptionGroupMixin
 from ._sections import Section, SectionMixin

--- a/cloup/_commands.py
+++ b/cloup/_commands.py
@@ -24,7 +24,7 @@ When and if the MyPy issue is resolved, the overloads will be removed.
 """
 import inspect
 from typing import (
-    Any, Callable, Dict, Iterable, List, NamedTuple, Optional, Sequence, Tuple,
+    Any, Callable, Dict, Iterable, List, NamedTuple, Optional, Tuple,
     Type, TypeVar, cast, overload,
 )
 
@@ -647,6 +647,7 @@ class _ArgInfo(NamedTuple):
     arg_name: str
     requires: Type
     supported_by: str = ""
+
 
 _ARGS_INFO = {
     info.arg_name: info for info in [

--- a/cloup/_commands.py
+++ b/cloup/_commands.py
@@ -112,6 +112,8 @@ class Command(ConstraintMixin, OptionGroupMixin, click.Command):
         self.format_aliases(ctx, formatter)
         self.format_help_text(ctx, formatter)
         self.format_params(ctx, formatter)
+        if self.must_show_constraints(ctx):
+            self.format_constraints(ctx, formatter)
         if isinstance(self, click.MultiCommand):
             self.format_commands(ctx, formatter)
         self.format_epilog(ctx, formatter)

--- a/cloup/_commands.py
+++ b/cloup/_commands.py
@@ -111,7 +111,7 @@ class Command(ConstraintMixin, OptionGroupMixin, click.Command):
         self.format_usage(ctx, formatter)
         self.format_aliases(ctx, formatter)
         self.format_help_text(ctx, formatter)
-        self.format_options(ctx, formatter)
+        self.format_params(ctx, formatter)
         if isinstance(self, click.MultiCommand):
             self.format_commands(ctx, formatter)
         self.format_epilog(ctx, formatter)

--- a/cloup/_context.py
+++ b/cloup/_context.py
@@ -154,12 +154,12 @@ class Context(click.Context):
         :param default_map:
             a dictionary (like object) with default values for parameters.
         :param terminal_width:
-            the width of the terminal.  The default is inherit from parent
-            context.  If no context defines the terminal width then auto
-            detection will be applied.
+            the width of the terminal. The default is inherited from parent
+            context. If no context defines the terminal width then auto-detection
+            will be applied.
         :param max_content_width:
             the maximum width for content rendered by Click (this currently
-            only affects help pages).  This defaults to 80 characters if not
+            only affects help pages). This defaults to 80 characters if not
             overridden. In other words: even if the terminal is larger than
             that, Click will not format things wider than 80 characters by
             default.  In addition to that, formatters might add some safety
@@ -184,8 +184,8 @@ class Context(click.Context):
             parameter is named. The default is ``['--help']``.
         :param token_normalize_func:
             an optional function that is used to normalize tokens (options,
-            choices, etc.). This for instance can be used to implement case
-            insensitive behavior.
+            choices, etc.). This for instance can be used to implement
+            case-insensitive behavior.
         :param color:
             controls if the terminal supports ANSI colors or not. The default
             is auto-detection. This is only needed if ANSI codes are used in

--- a/cloup/_option_groups.py
+++ b/cloup/_option_groups.py
@@ -245,7 +245,7 @@ class OptionGroupMixin:
         default_group.options = self.get_ungrouped_options(ctx)
         return default_group
 
-    def format_options(
+    def format_params(
         self, ctx: click.Context, formatter: click.HelpFormatter
     ) -> None:
         formatter = ensure_is_cloup_formatter(formatter)

--- a/cloup/_option_groups.py
+++ b/cloup/_option_groups.py
@@ -231,14 +231,17 @@ class OptionGroupMixin:
             default,
         )
 
-    def get_default_option_group(self, ctx: click.Context) -> OptionGroup:
+    def get_default_option_group(
+        self, ctx: click.Context, is_the_only_option_group: bool = False
+    ) -> OptionGroup:
         """
         Returns an ``OptionGroup`` instance for the options not explicitly
         assigned to an option group, eventually including the ``--help`` option.
 
         .. versionadded:: 0.8.0
         """
-        default_group = OptionGroup('Other options')
+        default_group = OptionGroup(
+            "Options" if is_the_only_option_group else "Other options")
         default_group.options = self.get_ungrouped_options(ctx)
         return default_group
 
@@ -256,10 +259,10 @@ class OptionGroupMixin:
             for group in self.option_groups
             if not group.hidden
         ]
-        if not visible_sections:  # No visible option groups. No custom formatting needed.
-            return super().format_options(ctx, formatter)  # type: ignore
 
-        default_group = self.get_default_option_group(ctx)
+        default_group = self.get_default_option_group(
+            ctx, is_the_only_option_group=not visible_sections
+        )
         if not default_group.hidden:
             visible_sections.append(
                 self.make_option_group_help_section(default_group, ctx))
@@ -268,8 +271,6 @@ class OptionGroupMixin:
             visible_sections,
             aligned=self.must_align_option_groups(ctx),
         )
-        if isinstance(self, click.MultiCommand):
-            self.format_commands(ctx, formatter)
 
 
 @overload

--- a/cloup/_params.py
+++ b/cloup/_params.py
@@ -1,6 +1,15 @@
 import click
 
 
+class Argument(click.Argument):
+    def __init__(self, *args, help=None, **attrs):
+        super().__init__(*args, **attrs)
+        self.help = help
+
+    def help_record(self, ctx):
+        return [self.make_metavar(), self.help or ""]
+
+
 class GroupedOption(click.Option):
     """A click.Option with an extra field ``group`` of type ``OptionGroup``."""
 
@@ -9,7 +18,8 @@ class GroupedOption(click.Option):
         self.group = group
 
 
-argument = click.argument
+def argument(*args, help=None, cls=Argument, **kwargs):
+    return click.argument(*args, help=help, cls=cls, **kwargs)
 
 
 def option(*param_decls, cls=None, group=None, **kwargs):

--- a/cloup/_params.pyi
+++ b/cloup/_params.pyi
@@ -1,7 +1,7 @@
 """
 Types for parameter decorators are in this stub for convenience of implementation.
 """
-from typing import Any, Callable, Optional, Sequence, Type, TypeVar, Union
+from typing import Any, Callable, Optional, Sequence, Tuple, Type, TypeVar, Union
 
 import click
 
@@ -27,9 +27,16 @@ ParamCallback = Callable[[click.Context, P, Any], Any]
 #     Union[List['CompletionItem'], List[str]],
 # ]
 
+class Argument(click.Argument):
+    def __init__(self, *args, help: Optional[str] = None, **attrs):
+        ...
+
+    def help_record(self, ctx: click.Context) -> Tuple[str, str]:
+        ...
+
 
 class GroupedOption(click.Option):
-    def __init__(self, *args, group: Optional[OptionGroup] = None, **kwargs):
+    def __init__(self, *args, group: Optional[OptionGroup] = None, **attrs):
         ...
 
 

--- a/cloup/constraints/_support.py
+++ b/cloup/constraints/_support.py
@@ -201,16 +201,13 @@ class ConstraintMixin:
             with formatter.section('Constraints'):
                 formatter.write_dl(records)
 
-    def format_options(self, ctx, formatter: HelpFormatter) -> None:
-        super().format_options(ctx, formatter)  # type: ignore
+    def must_show_constraints(self, ctx: Context) -> bool:
         # By default, don't show constraints
-        must_show_constraints = first_bool(
+        return first_bool(
             self.show_constraints,
             getattr(ctx, "show_constraints", None),
             False,
         )
-        if must_show_constraints:
-            self.format_constraints(ctx, formatter)
 
 
 def ensure_constraints_support(command) -> ConstraintMixin:

--- a/cloup/constraints/_support.py
+++ b/cloup/constraints/_support.py
@@ -3,7 +3,7 @@ from typing import (
     TYPE_CHECKING, Tuple, Union,
 )
 
-from click import Context, HelpFormatter, Parameter
+from click import Context, Parameter
 
 from ._core import Constraint
 from .common import join_param_labels

--- a/cloup/constraints/_support.py
+++ b/cloup/constraints/_support.py
@@ -201,8 +201,8 @@ class ConstraintMixin:
             with formatter.section('Constraints'):
                 formatter.write_dl(records)
 
-    def format_help(self, ctx, formatter: HelpFormatter) -> None:
-        super().format_help(ctx, formatter)  # type: ignore
+    def format_options(self, ctx, formatter: HelpFormatter) -> None:
+        super().format_options(ctx, formatter)  # type: ignore
         # By default, don't show constraints
         must_show_constraints = first_bool(
             self.show_constraints,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ Please, note that Cloup documentation doesn't replace
     :maxdepth: 2
 
     pages/installation
+    pages/arguments
     pages/option-groups
     pages/constraints
     pages/aliases

--- a/docs/pages/aliases.rst
+++ b/docs/pages/aliases.rst
@@ -73,7 +73,7 @@ Help output of the subcommand
 
 .. attention::
     Aliases are shown **only** in the ``--help`` output of subcommands that
-    extends ``cloup.BaseCommand``. So, normal ``click.Command`` won't do it.
+    extends ``cloup.Command``. So, normal ``click.Command`` won't do it.
 
 .. code-block:: text
     :emphasize-lines: 2

--- a/docs/pages/arguments.rst
+++ b/docs/pages/arguments.rst
@@ -1,0 +1,58 @@
+Arguments with ``help``
+=======================
+
+If you've used Click before, you probably know that:
+
+    ``click.argument()`` does not take a help parameter. This is to follow the
+    general convention of Unix tools of using arguments for only the most
+    necessary things, and to document them in the command help text by referring
+    to them by name.
+
+Cloup doesn't force the Unix convention on you. ``cloup.argument`` takes an
+optional ``help`` parameter. If you pass a non-empty string to at least one of
+the arguments of a command, Cloup will print a "Positional arguments" section
+just below the command description.
+
+.. tabbed:: Code
+    :new-group:
+
+    .. code-block:: python
+
+        from pprint import pprint
+        import cloup
+        from cloup import option, option_group
+
+        @cloup.command()
+        @cloup.argument('input_path', help="Input path")
+        @cloup.argument('out_path', help="Output path")
+        @option_group(
+            'An option group',
+            option('-o', '--one', help='a 1st cool option'),
+            option('-t', '--two', help='a 2nd cool option'),
+            option('--three', help='a 3rd cool option'),
+        )
+        def main(**kwargs):
+            """A test program for cloup."""
+            pprint(kwargs, indent=3)
+
+        main()
+
+.. tabbed:: Generated help
+
+    .. code-block:: none
+
+        Usage: example [OPTIONS] INPUT_PATH OUT_PATH
+
+          A test program for cloup.
+
+        Positional arguments:
+          INPUT_PATH      Input path
+          OUT_PATH        Output path
+
+        An option group:
+          -o, --one TEXT  a 1st cool option
+          -t, --two TEXT  a 2nd cool option
+          --three TEXT    a 3rd cool option
+
+        Other options:
+          --help          Show this message and exit.

--- a/docs/pages/option-groups.rst
+++ b/docs/pages/option-groups.rst
@@ -308,17 +308,7 @@ This features depends on two mixins:
 - (*required*) :class:`~cloup.OptionGroupMixin`
 - (*optional*) :class:`~cloup.ConstraintMixin`, if you want to use constraints.
 
-``cloup.Command`` is the only command class that supports this feature, including
-both these mixins.
+.. admonition:: New!
+    :class: tip
 
-.. attention::
-    ``cloup.Group`` doesn't support option groups nor constraints.
-    This is intentional: a ``Group`` should have only a few options, so they
-    should not need neither option groups nor constraints. (But I may be wrong;
-    if you disagree, open an issue describing your use case). Anyway, you can
-    easily subclass ``cloup.Group`` to include the above mixins::
-
-        from cloup import ConstraintMixin, OptionGroupMixin, Group
-
-        class MyGroup(ConstraintMixin, OptionGroupMixin, Group):
-            pass
+    Since Cloup v0.14.0, ``cloup.Group`` supports option groups and constraints only.

--- a/docs/pages/option-groups.rst
+++ b/docs/pages/option-groups.rst
@@ -1,4 +1,3 @@
-
 Option groups
 =============
 
@@ -48,7 +47,7 @@ Here's the full list of parameters:
         from cloup import option_group, option
         from cloup.constraints import RequireAtLeast
 
-        @cloup.command("clouptest")
+        @cloup.command()
         @option_group(
             "Input options",
             option("--one", help="1st input option"),
@@ -69,6 +68,8 @@ Here's the full list of parameters:
         def cli(**kwargs):
             """ A CLI that does nothing. """
             print(kwargs)
+
+        cli()
 
 .. tabbed:: Generated help
 

--- a/examples/arguments_with_help.py
+++ b/examples/arguments_with_help.py
@@ -1,0 +1,43 @@
+"""
+Show-casing the "Positional arguments" help section.
+"""
+from pprint import pprint
+
+import cloup
+from cloup import option, option_group
+
+
+@cloup.command(name='cloup', show_constraints=True)
+@cloup.argument('input_path', help="Input path")
+@cloup.argument('out_path', help="Output path")
+@option_group(
+    'An option group',
+    option('-o', '--one', help='a 1st cool option'),
+    option('-t', '--two', help='a 2nd cool option'),
+    option('--three', help='a 3rd cool option'),
+)
+def main(**kwargs):
+    """A test program for cloup."""
+    pprint(kwargs, indent=3)
+
+
+if __name__ == '__main__':
+    main()
+
+"""
+Usage: arguments_with_help.py [OPTIONS] INPUT_PATH OUT_PATH
+
+  A test program for cloup.
+
+Positional arguments:
+  INPUT_PATH      Input path
+  OUT_PATH        Output path
+
+An option group:
+  -o, --one TEXT  a 1st cool option
+  -t, --two TEXT  a 2nd cool option
+  --three TEXT    a 3rd cool option
+
+Other options:
+  --help          Show this message and exit.
+"""

--- a/examples/manim/render.py
+++ b/examples/manim/render.py
@@ -6,8 +6,8 @@ from cloup.constraints import ErrorFmt, mutually_exclusive
 
 
 @command(aliases=["r", "re"])
-@argument("script_path", type=cloup.Path(), required=True)
-@argument("scene_names", required=False, nargs=-1)
+@argument("script_path", help="Script path.", type=cloup.Path(), required=True)
+@argument("scene_names", help="Name of the scenes.", required=False, nargs=-1)
 @option_group(
     "Global options",
     option(

--- a/examples/option_groups.py
+++ b/examples/option_groups.py
@@ -18,8 +18,8 @@ from cloup.constraints import (
 
 
 @cloup.command(name='cloup', show_constraints=True)
-@cloup.argument('input_path', help="Input path")
-@cloup.argument('out_path', help="Output path")
+@cloup.argument('input_path')
+@cloup.argument('out_path')
 @option_group(
     'First group title',
     "This is a very long description of the option group. I don't think this is "
@@ -51,4 +51,4 @@ def main(**kwargs):
 
 
 if __name__ == '__main__':
-    main("--help".split())
+    main()

--- a/examples/option_groups.py
+++ b/examples/option_groups.py
@@ -18,7 +18,8 @@ from cloup.constraints import (
 
 
 @cloup.command(name='cloup', show_constraints=True)
-@cloup.argument('arg', required=False)   # alias of click.argument
+@cloup.argument('input_path', help="Input path")
+@cloup.argument('out_path', help="Output path")
 @option_group(
     'First group title',
     "This is a very long description of the option group. I don't think this is "
@@ -50,4 +51,4 @@ def main(**kwargs):
 
 
 if __name__ == '__main__':
-    main()
+    main("--help".split())

--- a/tests/constraints/test_support.py
+++ b/tests/constraints/test_support.py
@@ -1,4 +1,5 @@
 import textwrap
+from typing import Sequence
 from unittest.mock import Mock
 
 import click
@@ -6,16 +7,12 @@ import pytest
 from click import Argument, Option
 
 import cloup
-from cloup import ConstraintMixin, Context
-from cloup._util import pick_non_missing
-from cloup.typing import MISSING
+from cloup import Context
+from cloup._util import pick_non_missing, reindent
 from cloup.constraints import Constraint, RequireAtLeast, mutually_exclusive
+from cloup.typing import MISSING
 from tests.constraints.test_constraints import FakeConstraint
 from tests.util import new_dummy_func, pick_first_bool
-
-
-class Cmd(ConstraintMixin, click.Command):
-    pass
 
 
 class TestConstraintMixin:
@@ -25,7 +22,7 @@ class TestConstraintMixin:
             Option(('--str-opt',)),
             Option(('--int-opt', 'option2')),
         ]
-        cmd = Cmd(name='cmd', params=params, callback=new_dummy_func())
+        cmd = cloup.Command(name='cmd', params=params, callback=new_dummy_func())
         for param in params:
             assert cmd.get_param_by_name(param.name) == param
 
@@ -35,18 +32,23 @@ class TestConstraintMixin:
         assert cmd.get_params_by_name(['arg1', 'option2']) == (params[0], params[2])
 
 
-@pytest.mark.parametrize(
-    'do_check_consistency', [True, False],
-    ids=['with_consistency_checks', 'without_consistency_checks']
-)
-def test_constraints_are_checked_according_to_protocol(runner, do_check_consistency):
+@pytest.mark.parametrize('command_type', ["command", "group"])
+@pytest.mark.parametrize('do_check_consistency', [
+    pytest.param(True, id="with_consistency_checks"),
+    pytest.param(False, id="without_consistency_checks")
+])
+def test_constraints_are_checked_according_to_protocol(
+    runner, command_type, do_check_consistency
+):
     constraints = [
         Mock(spec_set=Constraint, wraps=FakeConstraint())
         for _ in range(3)
     ]
     settings = Context.settings(check_constraints_consistency=do_check_consistency)
 
-    @cloup.command(context_settings=settings)
+    command_decorator = cloup.group if command_type == "group" else cloup.command
+
+    @command_decorator(context_settings=settings)
     @cloup.option_group('first', cloup.option('--a'), cloup.option('--b'),
                         constraint=constraints[0])
     @cloup.option_group('second', cloup.option('--c'), cloup.option('--d'),
@@ -57,7 +59,12 @@ def test_constraints_are_checked_according_to_protocol(runner, do_check_consiste
         assert Constraint.must_check_consistency(ctx) == do_check_consistency
         print(f'{a}, {b}, {c}, {d}')
 
-    result = runner.invoke(cmd, args='--a=1 --c=2'.split())
+    shell = '--a=1 --c=2'
+    if isinstance(cmd, cloup.Group):
+        cmd.add_command(cloup.Command(name="dummy", callback=lambda: 0))
+        shell += ' dummy'
+
+    result = runner.invoke(cmd, args=shell.split())
 
     assert result.output.strip() == '1, None, 2, None'
     for constr, opt_names in zip(constraints, [['a', 'b'], ['c', 'd'], ['a', 'c']]):
@@ -69,6 +76,7 @@ def test_constraints_are_checked_according_to_protocol(runner, do_check_consiste
         constr.check_values.assert_called_once()
 
 
+@pytest.mark.parametrize('command_type', ["command", "group"])
 @pytest.mark.parametrize(
     'cmd_value', [MISSING, None, True, False],
     ids=lambda val: f'cmd_{val}'
@@ -78,7 +86,7 @@ def test_constraints_are_checked_according_to_protocol(runner, do_check_consiste
     ids=lambda val: f'ctx_{val}'
 )
 def test_constraints_are_shown_in_help_only_if_feature_is_enabled(
-    runner, cmd_value, ctx_value
+    runner, command_type, cmd_value, ctx_value
 ):
     should_show = pick_first_bool([cmd_value, ctx_value], default=False)
     cxt_settings = pick_non_missing(dict(
@@ -90,7 +98,9 @@ def test_constraints_are_shown_in_help_only_if_feature_is_enabled(
         context_settings=cxt_settings
     ))
 
-    @cloup.command(**cmd_kwargs)
+    command_decorator = cloup.group if command_type == "group" else cloup.command
+
+    @command_decorator(**cmd_kwargs)
     @cloup.option('--a')
     @cloup.option('--b')
     @cloup.option('--c')
@@ -99,28 +109,47 @@ def test_constraints_are_shown_in_help_only_if_feature_is_enabled(
     def cmd(a, b, c, d):
         pass
 
+    if isinstance(cmd, cloup.Group):
+        cmd.add_command(cloup.Command(name="dummy", callback=lambda: 0))
+
     result = runner.invoke(cmd, args=['--help'],
                            catch_exceptions=False,
                            prog_name='test')
-    out = result.output.strip()
+    out = result.output
 
-    if should_show:
-        expected = textwrap.dedent('''
-            Usage: test [OPTIONS]
+    if command_type == "group":
+        if should_show:
+            assert out == reindent("""
+                Usage: test [OPTIONS] COMMAND [ARGS]...
 
-            Options:
-              --a TEXT
-              --b TEXT
-              --c TEXT
-              --help    Show this message and exit.
+                Options:
+                  --a TEXT
+                  --b TEXT
+                  --c TEXT
+                  --help    Show this message and exit.
 
-            Constraints:
-              {--a, --b}  a constraint
-              {--b, --c}  another constraint
-        ''').strip()
-        assert out == expected
+                Constraints:
+                  {--a, --b}  a constraint
+                  {--b, --c}  another constraint
+
+                Commands:
+                  dummy
+            """)
+        else:
+            assert out == reindent("""
+                Usage: test [OPTIONS] COMMAND [ARGS]...
+
+                Options:
+                  --a TEXT
+                  --b TEXT
+                  --c TEXT
+                  --help    Show this message and exit.
+
+                Commands:
+                  dummy
+            """)
     else:
-        expected = textwrap.dedent('''
+        base_help = reindent("""
             Usage: test [OPTIONS]
 
             Options:
@@ -128,8 +157,18 @@ def test_constraints_are_shown_in_help_only_if_feature_is_enabled(
               --b TEXT
               --c TEXT
               --help    Show this message and exit.
-        ''').strip()
-        assert out == expected
+        """)
+
+        if should_show:
+            constraints_section = reindent("""
+                Constraints:
+                  {--a, --b}  a constraint
+                  {--b, --c}  another constraint
+            """)
+            expected = base_help + "\n" + constraints_section
+            assert out == expected
+        else:
+            assert out == base_help
 
 
 def test_usage_of_constraints_as_decorators(runner):

--- a/tests/constraints/test_support.py
+++ b/tests/constraints/test_support.py
@@ -1,5 +1,3 @@
-import textwrap
-from typing import Sequence
 from unittest.mock import Mock
 
 import click

--- a/tests/example_command.py
+++ b/tests/example_command.py
@@ -4,7 +4,7 @@ from typing import cast
 import click
 
 import cloup
-from cloup import Command, HelpFormatter, option, option_group
+from cloup import Command, HelpFormatter, argument, option, option_group
 from cloup.constraints import AcceptAtMost, If, RequireAtLeast
 
 
@@ -21,6 +21,8 @@ def make_example_command(
         ),
         epilog='Made with love by Gianluca.'
     )
+    @argument("arg_one", help="This is the description of argument #1.")
+    @argument("arg_two", help="This is the description of argument #2.", required=False)
     @option_group(
         'Option group A',
         option('--one', help='The one thing you need to run this command.'),
@@ -60,9 +62,13 @@ def make_example_command(
 
 
 _TABULAR_ALIGNED_HELP = """
-Usage: clouptest [OPTIONS]
+Usage: clouptest [OPTIONS] ARG_ONE [ARG_TWO]
 
   A CLI that does nothing.
+
+Positional arguments:
+  ARG_ONE               This is the description of argument #1.
+  [ARG_TWO]             This is the description of argument #2.
 
 Option group A: [at most 2 accepted]
   This is a very useful description of group A. This is a rarely used feature
@@ -88,9 +94,13 @@ Made with love by Gianluca.
 """.strip()
 
 _TABULAR_NON_ALIGNED_HELP = """
-Usage: clouptest [OPTIONS]
+Usage: clouptest [OPTIONS] ARG_ONE [ARG_TWO]
 
   A CLI that does nothing.
+
+Positional arguments:
+  ARG_ONE    This is the description of argument #1.
+  [ARG_TWO]  This is the description of argument #2.
 
 Option group A: [at most 2 accepted]
   This is a very useful description of group A. This is a rarely used feature
@@ -115,9 +125,16 @@ Made with love by Gianluca.
 """.strip()
 
 _LINEAR_HELP = """
-Usage: clouptest [OPTIONS]
+Usage: clouptest [OPTIONS] ARG_ONE [ARG_TWO]
 
   A CLI that does nothing.
+
+Positional arguments:
+  ARG_ONE
+     This is the description of argument #1.
+
+  [ARG_TWO]
+     This is the description of argument #2.
 
 Option group A: [at most 2 accepted]
   This is a very useful description of group A. This is a rarely used feature

--- a/tests/example_group.py
+++ b/tests/example_group.py
@@ -1,6 +1,6 @@
 # flake8: noqa E128
 import cloup
-from cloup import Section
+from cloup import Section, argument, option, option_group
 
 
 def make_example_group(align_sections):
@@ -22,7 +22,16 @@ def make_example_group(align_sections):
         'mv', help='Move or rename a file, a directory, or a symlink')(f)
 
     @cloup.group(
-        'git', align_sections=align_sections, context_settings={'terminal_width': 80})
+        'git',
+        align_sections=align_sections,
+        align_option_groups=align_sections,
+        context_settings={'terminal_width': 80},
+    )
+    @option_group(
+        "Useful options",
+        option("-C", type=cloup.Path(), help="Configuration file."),
+        option("-p", "--paginate", is_flag=True, help="Paginate output."),
+    )
     def git():
         return 0
 
@@ -49,8 +58,12 @@ def make_example_group(align_sections):
 EXPECTED_ALIGNED_HELP = """
 Usage: git [OPTIONS] COMMAND [ARGS]...
 
-Options:
-  --help  Show this message and exit.
+Useful options:
+  -C PATH         Configuration file.
+  -p, --paginate  Paginate output.
+
+Other options:
+  --help          Show this message and exit.
 
 Start a working area (see also: git help tutorial):
   init             Create an empty Git repository or reinitialize an existing...
@@ -69,7 +82,11 @@ Other commands:
 EXPECTED_NON_ALIGNED_HELP = """
 Usage: git [OPTIONS] COMMAND [ARGS]...
 
-Options:
+Useful options:
+  -C PATH         Configuration file.
+  -p, --paginate  Paginate output.
+
+Other options:
   --help  Show this message and exit.
 
 Start a working area (see also: git help tutorial):

--- a/tests/test_option_groups.py
+++ b/tests/test_option_groups.py
@@ -47,13 +47,13 @@ def test_option_groups_are_correctly_displayed_in_help(
 def test_option_group_constraints_are_checked(runner, get_example_command):
     cmd = get_example_command(align_option_groups=False)
 
-    result = runner.invoke(cmd, args='--one=1')
+    result = runner.invoke(cmd, args='arg1 --one=1')
     assert result.exit_code == 0
 
-    result = runner.invoke(cmd, args='--one=1 --three=3 --five=4')
+    result = runner.invoke(cmd, args='arg1 --one=1 --three=3 --five=4')
     assert result.exit_code == 0
 
-    result = runner.invoke(cmd, args='--one=1 --three=3')
+    result = runner.invoke(cmd, args='arg1 --one=1 --three=3')
     assert result.exit_code == 2
     error_prefix = ('Error: when --three is set, at least 1 of the following '
                     'parameters must be set')


### PR DESCRIPTION
## Implementation notes
The main goal for this PR was:
- #106.

Implementing this feature was nonetheless more complex than I expected and required many changes, some of them breaking changes. 

The feature was integrated in `OptionGroupMixin`, which I'll rename to `ParamSectioMixin` in a subsequent PR. The reason is that I wanted the "Positional arguments" section to be aligned with option groups.

In order to support the "Positional arguments" section in groups as well, I had to include `OptionGroupMixin` in `Group` superclasses. I decided to remove `BaseCommand` and make `Group` inherits from `Command` directly. This closes:
- #112

See below for a list of breaking changes.

Closes #106. 
Closes #112.

The following sections are copied from the CHANGELOG.rst

## New features and enhancements
- You can show a "Positional arguments" help section by passing a non-empty``help`` description for at least one of the arguments of a command/group.
- ``cloup.Group`` now extends ``cloup.Command`` and, as a consequence, supports option groups and constraints.

## Breaking changes
- ``BaseCommand`` was removed. This shouldn't cause any issue to anybody.
- ``cloup.Group`` extends ``cloup.Command``, similarly as ``click.Group`` extends ``click.Command``.
- ``OptionGroupMixin.format_options`` was renamed to ``format_params``. This means you can't just mix it with ``click.Command`` to print help sections for option groups, you have to override ``format_help`` and call ``format_params``.
- The new ``format_params`` doesn't call ``super().format_commands`` as ``format_options`` did: that's what Click does and Cloup (reluctantly) did. Now, instead, ``cloup.Command`` calls ``format_params`` in ``format_help`` and then, for multi-commands, calls ``format_commands`` directly.
- ``ConstraintMixin.format_help`` was removed. This means you can't just mix it with a click.Command to make it print the "Constraints" help section, you need to call ``format_constraints`` explicitly in your command ``format_help``.