### PR TITLE
Move calls to `super().__init__` forward

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,8 @@ v0.15.0 (in development)
 New features and enhancements
 -----------------------------
 - Renamed ``Argument.help_record`` to ``Argument.get_help_record``. :pr:`116`
-- Fixed typos around.
+- Fixed typos and some type annotations. :pr:`116`
+- In mixins, moved call to ``super()`` at the beginning of ``__init__``. :pr:`119`.
 
 Bug fixes
 ---------
@@ -26,6 +27,7 @@ Bug fixes
 Breaking changes
 ----------------
 - Renamed ``Argument.help_record`` to ``Argument.get_help_record``.
+- In mixins, moved call to ``super()`` at the beginning of ``__init__``. :pr:`119`.
 
 Deprecated
 ----------

--- a/cloup/_context.py
+++ b/cloup/_context.py
@@ -75,6 +75,7 @@ class Context(click.Context):
         **ctx_kwargs,
     ):
         super().__init__(*ctx_args, **ctx_kwargs)
+
         self.align_option_groups = coalesce(
             align_option_groups,
             getattr(self.parent, 'align_option_groups', None),

--- a/cloup/_option_groups.py
+++ b/cloup/_option_groups.py
@@ -130,6 +130,8 @@ class OptionGroupMixin:
         :param kwargs:
             keyword arguments forwarded to the next class in the MRO
         """
+        super().__init__(*args, **kwargs)  # type: ignore
+
         self.align_option_groups = align_option_groups
         params = kwargs.get('params') or []
         arguments, option_groups, ungrouped_options = self._group_params(params)
@@ -146,8 +148,6 @@ class OptionGroupMixin:
         based on context settings, like the ``--help`` option; use the
         :meth:`get_ungrouped_options` method if you need the real full list
         (which needs a ``Context`` object)."""
-
-        super().__init__(*args, **kwargs)  # type: ignore
 
     @staticmethod
     def _group_params(

--- a/cloup/_sections.py
+++ b/cloup/_sections.py
@@ -122,13 +122,13 @@ class SectionMixin:
         :param kwargs:
             keyword arguments forwarded to the next class in the MRO
         """
+        super().__init__(*args, commands=commands, **kwargs)  # type: ignore
         self.align_sections = align_sections
         self._default_section = Section('__DEFAULT', commands=commands or [])
         self._user_sections: List[Section] = []
         self._section_set = {self._default_section}
         for section in sections:
             self.add_section(section)
-        super().__init__(*args, commands=commands, **kwargs)  # type: ignore
 
     def _add_command_to_section(self, cmd, name=None, section=None):
         """Adds a command to the section (if specified) or to the default section."""

--- a/cloup/constraints/_core.py
+++ b/cloup/constraints/_core.py
@@ -482,9 +482,9 @@ class RequireExactly(WrapperConstraint):
 
     def __init__(self, n: int):
         check_arg(n > 0)
-        self.num_params = n
         # Defined as a wrapper to reuse check_consistency() of the wrapped constraint.
         super().__init__(RequireAtLeast(n) & AcceptAtMost(n))
+        self.num_params = n
 
     def help(self, ctx: Context) -> str:
         return f'exactly {self.num_params} required'
@@ -516,9 +516,9 @@ class AcceptBetween(WrapperConstraint):
         check_arg(min >= 0, 'min must be non-negative')
         if max is not None:
             check_arg(min < max, 'must be: min < max.')
+        super().__init__(RequireAtLeast(min) & AcceptAtMost(max), min=min, max=max)
         self.min_num_params = min
         self.max_num_params = max
-        super().__init__(RequireAtLeast(min) & AcceptAtMost(max), min=min, max=max)
 
     def help(self, ctx: Context) -> str:
         return f'at least {self.min_num_params} required, ' \

--- a/cloup/constraints/_support.py
+++ b/cloup/constraints/_support.py
@@ -143,6 +143,7 @@ class ConstraintMixin:
             keyword arguments forwarded to the next class in the MRO
         """
         super().__init__(*args, **kwargs)  # type: ignore
+
         self.show_constraints = show_constraints
 
         # This allows constraints to efficiently access parameters by name


### PR DESCRIPTION
That is, moved all the calls to `super().__init__` previously at the end of `__init__` methods as early as possible.

Resolves #118.