### PR TITLE
Fix title of default option group when the only other visible section is "Positional arguments"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,8 @@ New features and enhancements
 
 Bug fixes
 ---------
+- The title of the default option group was "Other options" when the only other
+  parameter help section was "Positional arguments". It's now "Options". :pr:`120`
 
 Breaking changes
 ----------------

--- a/cloup/_option_groups.py
+++ b/cloup/_option_groups.py
@@ -233,7 +233,7 @@ class OptionGroupMixin:
         )
 
     def get_default_option_group(
-        self, ctx: click.Context, is_the_only_option_group: bool = False
+        self, ctx: click.Context, is_the_only_visible_option_group: bool = False
     ) -> OptionGroup:
         """
         Returns an ``OptionGroup`` instance for the options not explicitly
@@ -242,7 +242,7 @@ class OptionGroupMixin:
         .. versionadded:: 0.8.0
         """
         default_group = OptionGroup(
-            "Options" if is_the_only_option_group else "Other options")
+            "Options" if is_the_only_visible_option_group else "Other options")
         default_group.options = self.get_ungrouped_options(ctx)
         return default_group
 
@@ -252,21 +252,26 @@ class OptionGroupMixin:
         formatter = ensure_is_cloup_formatter(formatter)
 
         visible_sections = []
+
+        # Positional arguments
         positional_arguments_section = self.get_arguments_help_section(ctx)
         if positional_arguments_section:
             visible_sections.append(positional_arguments_section)
-        visible_sections += [
+
+        # Option groups
+        option_group_sections = [
             self.make_option_group_help_section(group, ctx)
             for group in self.option_groups
             if not group.hidden
         ]
-
         default_group = self.get_default_option_group(
-            ctx, is_the_only_option_group=not visible_sections
+            ctx, is_the_only_visible_option_group=not option_group_sections
         )
         if not default_group.hidden:
-            visible_sections.append(
+            option_group_sections.append(
                 self.make_option_group_help_section(default_group, ctx))
+
+        visible_sections += option_group_sections
 
         formatter.write_many_sections(
             visible_sections,

--- a/tests/test_option_groups.py
+++ b/tests/test_option_groups.py
@@ -8,9 +8,9 @@ from click import pass_context
 
 import cloup
 from cloup import OptionGroup, option, option_group
-from cloup._util import pick_non_missing
-from cloup.typing import MISSING
+from cloup._util import pick_non_missing, reindent
 from cloup.constraints import RequireAtLeast, mutually_exclusive
+from cloup.typing import MISSING
 from tests.util import (make_options, new_dummy_func, parametrize, pick_first_bool)
 
 
@@ -274,3 +274,25 @@ def test_option_groups_raises_if_input_decorator_add_an_argument():
                 cloup.option('--opt')
             )
         )(new_dummy_func())
+
+
+def test_default_option_group_title_when_the_only_other_section_is_positional_arguments(
+    runner
+):
+    @cloup.command()
+    @cloup.argument("arg", help="An argument.")
+    @cloup.option("--opt", help="An option.")
+    def cmd(**kwargs):
+        pass
+
+    res = runner.invoke(cmd, ["--help"])
+    assert res.output == reindent("""
+        Usage: cmd [OPTIONS] ARG
+
+        Positional arguments:
+          ARG         An argument.
+
+        Options:
+          --opt TEXT  An option.
+          --help      Show this message and exit.
+    """)


### PR DESCRIPTION
Context: we have two help sections, the "Positional arguments" section and the default option group section.
The title of the default option group section should be in this case "Options". Instead is: "Other options".

This PR fixes it.