### PR TITLE
Work around Click bug: make decorators returned by @argument reusable (and more)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,14 +13,18 @@ Changelog
     Deprecated
     ----------
 
-v0.X.X (in development)
-=======================
+v0.15.1 (2022-06-26)
+====================
 
 Bug fixes
 ---------
 - Fix type of ``type`` argument of ``@option`` and ``@argument``. Specifically,
   tuple types weren't correctly described.
-
+- Reimplement ``@argument`` and ``@option`` without calling the corresponding
+  Click methods (:pr:`124`):
+    - make decorators returned by ``@argument`` reusable by not relying on bugged
+      Click implementation
+    - remove unnecessary copy of ``**attrs`` in ``@option``.
 
 v0.15.0 (2022-06-16)
 ====================

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ install: clean ## install the package in dev mode
 
 .PHONY: mypy
 mypy: ## check code, tests and examples with mypy
-	mypy cloup tests examples
+	mypy cloup --strict
+	mypy tests examples
 
 .PHONY: lint
 lint: ## check code, tests and examples with flake8

--- a/cloup/_params.pyi
+++ b/cloup/_params.pyi
@@ -39,7 +39,8 @@ class Option(click.Option):
 
 def argument(
     *param_decls: str,
-    cls: Optional[Type[click.Argument]] = None,
+    cls: Optional[Type[Argument]] = None,
+    help: Optional[str] = None,
     type: Optional[ParamTypeLike] = None,
     required: Optional[bool] = None,
     default: Optional[ParamDefault] = None,


### PR DESCRIPTION
The `@click.argument` function doesn't return reusable decorators:
- https://github.com/pallets/click/issues/2294

I opened a PR in Click that fixes this issue and also improves the `@option` decorator making copying `**attrs` unnecessary:
- https://github.com/pallets/click/pull/2312

I don't want to wait for the next click release, thus this PR, where I reimplement `@argument` and `@option` without calling the homonym Click decorators.