### PR TITLE
Rename __constraints attribute to __cloup_constraints__

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,11 @@ Changelog
     Deprecated
     ----------
 
+v1.x.x (in development)
+=======================
+- Rename ``__constraints`` attribute to ``__cloup_constraints__`` to make it
+  easier to access e.g. from class based decorators, if needed. :issue:`131`
+
 v1.0.2 (2022-11-04)
 =======================
 - Skip constraints checking when passing ``--help`` to a subcommand. :issue:`129`

--- a/cloup/_commands.py
+++ b/cloup/_commands.py
@@ -522,13 +522,13 @@ def command(
         )
 
     def decorator(f: AnyCallable) -> ClickCommand:
-        if hasattr(f, '__constraints'):
+        if hasattr(f, '__cloup_constraints__'):
             if cls and not issubclass(cls, ConstraintMixin):
                 raise TypeError(
                     f"a Command must inherit from cloup.ConstraintMixin to support "
                     f"constraints; {cls} doesn't")
-            constraints = tuple(reversed(f.__constraints))  # type: ignore
-            del f.__constraints  # type: ignore
+            constraints = tuple(reversed(f.__cloup_constraints__))  # type: ignore
+            del f.__cloup_constraints__  # type: ignore
             kwargs['constraints'] = constraints
 
         cmd_cls = cls if cls is not None else Command

--- a/cloup/constraints/_support.py
+++ b/cloup/constraints/_support.py
@@ -30,9 +30,9 @@ class BoundConstraintSpec(NamedTuple):
 def _constraint_memo(
     f: Any, constr: Union[BoundConstraintSpec, 'BoundConstraint']
 ) -> None:
-    if not hasattr(f, '__constraints'):
-        f.__constraints = []
-    f.__constraints.append(constr)
+    if not hasattr(f, '__cloup_constraints__'):
+        f.__cloup_constraints__ = []
+    f.__cloup_constraints__.append(constr)
 
 
 def constraint(constr: Constraint, params: Iterable[str]) -> Callable[[F], F]:


### PR DESCRIPTION
Unlike `__constraints`, `__cloup_constraints__` is not name-mangled which allows for easier access if needed.

Fixes #131.