### PR TITLE
Stop using deprecated pytest.warns(None)

### DIFF
--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -19,22 +19,23 @@ from tests.util import parametrize
     pytest.param(80, 90, True, id='both'),
 )
 def test_warning_is_raised_iff_arg_is_provided_both_as_context_and_formatter_arg(
-    ctx_arg_name, formatter_arg_name, ctx_arg_value, formatter_arg_value, should_warn
+    ctx_arg_name, formatter_arg_name, ctx_arg_value, formatter_arg_value, should_warn,
+    recwarn
 ):
     kwargs = {
         ctx_arg_name: ctx_arg_value,
         "formatter_settings": {formatter_arg_name: formatter_arg_value}
     }
 
-    with pytest.warns(None) as warns:
-        Context(command=Mock(), **kwargs)
+    Context(command=Mock(), **kwargs)
+
     if should_warn:
-        assert len(warns) == 1
-        warning = warns[0]
+        assert len(recwarn) == 1
+        warning = recwarn.pop(UserWarning)
         assert warning.category is UserWarning
         assert 'You provided both' in str(warning.message)
     else:
-        assert len(warns) == 0
+        assert len(recwarn) == 0
 
 
 @parametrize(
@@ -42,15 +43,14 @@ def test_warning_is_raised_iff_arg_is_provided_both_as_context_and_formatter_arg
     pytest.param('terminal_width', 'width', id='width'),
     pytest.param('max_content_width', 'max_width', id='max_width'),
 )
-def test_warning_suppression(ctx_arg_name, formatter_arg_name):
+def test_warning_suppression(ctx_arg_name, formatter_arg_name, recwarn):
     kwargs = {
         ctx_arg_name: 80, "formatter_settings": {formatter_arg_name: 90}
     }
     cloup.warnings.formatter_settings_conflict = False
-    with pytest.warns(None) as warns:
-        Context(command=Mock(), **kwargs)
+    Context(command=Mock(), **kwargs)
     cloup.warnings.formatter_settings_conflict = True
-    assert len(warns) == 0
+    assert len(recwarn) == 0
 
 
 def test_context_settings_creation():


### PR DESCRIPTION
Closes #135.