### PR TITLE
Standardize formats of error messages

### DIFF
--- a/cloup/_commands.py
+++ b/cloup/_commands.py
@@ -518,15 +518,15 @@ def command(
     if callable(name):
         raise Exception(
             f"you forgot parenthesis in the command decorator for `{name.__name__}`. "
-            f"While parenthesis are optional in Click > 8.1, they are required in Cloup."
+            f"While parenthesis are optional in Click >= 8.1, they are required in Cloup."
         )
 
     def decorator(f: AnyCallable) -> ClickCommand:
         if hasattr(f, '__cloup_constraints__'):
             if cls and not issubclass(cls, ConstraintMixin):
                 raise TypeError(
-                    f"a Command must inherit from cloup.ConstraintMixin to support "
-                    f"constraints; {cls} doesn't")
+                    f"a `Command` must inherit from `cloup.ConstraintMixin` to support "
+                    f"constraints; `{cls}` doesn't")
             constraints = tuple(reversed(f.__cloup_constraints__))
             del f.__cloup_constraints__
             kwargs['constraints'] = constraints
@@ -674,7 +674,7 @@ def group(
         return command(name=name, cls=cls, **kwargs)
     else:
         raise TypeError(
-            'this decorator requires cls to be a click.Group (or a subclass).')
+            'this decorator requires `cls` to be a `click.Group` (or a subclass)')
 
 
 # Side stuff for better error messages
@@ -687,10 +687,10 @@ class _ArgInfo(NamedTuple):
 
 _ARGS_INFO = {
     info.arg_name: info for info in [
-        _ArgInfo('formatter_settings', Command, "both Command and Group"),
-        _ArgInfo('align_option_groups', OptionGroupMixin, "both Command and Group"),
-        _ArgInfo('show_constraints', ConstraintMixin, "both Command and Group"),
-        _ArgInfo('align_sections', SectionMixin, "Group")
+        _ArgInfo('formatter_settings', Command, "both `Command` and `Group`"),
+        _ArgInfo('align_option_groups', OptionGroupMixin, "both `Command` and `Group`"),
+        _ArgInfo('show_constraints', ConstraintMixin, "both `Command` and `Group`"),
+        _ArgInfo('align_sections', SectionMixin, "`Group`")
     ]
 }
 
@@ -710,9 +710,9 @@ def _process_unexpected_kwarg_error(
     arg = match.group()
     info = args_info[arg]
     extra_info = reindent(f"""\n
-        HINT: you set cls={cls} but this class doesn't support the argument "{arg}".
-        In Cloup, this argument is supported by {info.supported_by}
-        via {info.requires.__name__}.
+        Hint: you set `cls={cls}` but this class doesn't support the argument `{arg}`.
+        In Cloup, this argument is supported by `{info.supported_by}`
+        via `{info.requires.__name__}`.
     """, 4)
     new_message = message + '\n' + extra_info
     return TypeError(new_message)

--- a/cloup/_option_groups.py
+++ b/cloup/_option_groups.py
@@ -353,8 +353,8 @@ def _option_group(
 ) -> Callable[[F], F]:
     if not isinstance(title, str):
         raise TypeError(
-            'the first argument of @option_group must be its title, a string. '
-            'You probably forgot it!'
+            'the first argument of `@option_group` must be its title, a string; '
+            'you probably forgot it'
         )
 
     if not options:
@@ -376,8 +376,9 @@ def _option_group(
                 existing_group = get_option_group_of(new_option)
                 if existing_group is not None:
                     raise ValueError(
-                        f'{new_option} was first assigned to {existing_group} and then '
-                        f'passed as argument to @option_group({title!r}, ...)'
+                        f'Option "{new_option}" was first assigned to group '
+                        f'"{existing_group}" and then passed as argument to '
+                        f'`@option_group({title!r}, ...)`'
                     )
                 new_option.group = opt_group  # type: ignore
                 if hidden:

--- a/cloup/_sections.py
+++ b/cloup/_sections.py
@@ -30,13 +30,13 @@ class Section:
                  is_sorted: bool = False):  # noqa
         """
         :param title:
-        :param commands: sequence of commands or dictionary {name: command}
+        :param commands: sequence of commands or dict of commands keyed by name
         :param is_sorted:
             if True, ``list_commands()`` returns the commands in lexicographic order
         """
         if not isinstance(title, str):
             raise TypeError(
-                'the first argument must be a string, the title. You probably forgot it.')
+                'the first argument must be a string, the title; you probably forgot it')
         self.title = title
         self.is_sorted = is_sorted
         self.commands: OrderedDict[str, click.Command] = OrderedDict()
@@ -47,8 +47,8 @@ class Section:
         elif isinstance(commands, dict):
             self.commands = OrderedDict(commands)
         else:
-            raise TypeError('the argument "commands" must be a list of commands '
-                            'or a dict {name: command}')
+            raise TypeError('argument `commands` must be a sequence of commands '
+                            'or a dict of commands keyed by name')
 
     @classmethod
     def sorted(cls, title: str, commands: Subcommands = ()) -> 'Section':
@@ -59,7 +59,7 @@ class Section:
         if not name:
             raise TypeError('missing command name')
         if name in self.commands:
-            raise Exception('command "{}" already exists'.format(name))
+            raise Exception(f'command "{name}" already exists')
         self.commands[name] = cmd
 
     def list_commands(self) -> List[Tuple[str, click.Command]]:
@@ -148,7 +148,7 @@ class SectionMixin:
         """ Adds a :class:`Section` to this group. You can add the same
         section object a single time. """
         if section in self._section_set:
-            raise ValueError(f'{section} was already added')
+            raise ValueError(f'section "{section}" was already added')
         self._user_sections.append(section)
         self._section_set.add(section)
         for name, cmd in section.commands.items():

--- a/cloup/_util.py
+++ b/cloup/_util.py
@@ -109,7 +109,9 @@ def check_positive_int(value: Any, arg_name: str) -> None:
     elif value <= 0:
         error_type = ValueError
     if error_type:
-        raise error_type(f'{arg_name} should be a positive integer. It is: {value}.')
+        raise error_type(
+            f'argument `{arg_name}` should be a positive integer; it is {value!r}'
+        )
 
 
 def identity(x: T) -> T:

--- a/cloup/constraints/_conditional.py
+++ b/cloup/constraints/_conditional.py
@@ -19,7 +19,7 @@ def as_predicate(arg: Union[str, Sequence[str], Predicate]) -> Predicate:
     elif isinstance(arg, Sequence):
         return AllSet(*arg)
     else:
-        raise TypeError('arg should be a string, a list of string or a Predicate')
+        raise TypeError('`arg` should be a string, a list of strings or a `Predicate`')
 
 
 class If(Constraint):

--- a/cloup/constraints/_core.py
+++ b/cloup/constraints/_core.py
@@ -53,9 +53,10 @@ class Constraint(abc.ABC):
         removed_attrs = ('toggle_consistency_checks', 'consistency_checks_toggled')
         if attr in removed_attrs:
             raise Exception(
-                f'{attr} was removed in v0.9.0. You can now enable/disable consistency'
-                f'checks using the click.Context parameter check_constraints_consistency.'
-                f' Pass it as part of your context_settings.'
+                f'attribute `{attr}` was removed in v0.9. You can now enable/disable '
+                f'consistency checks using the `click.Context` parameter '
+                f'`check_constraints_consistency`. '
+                f'Pass it as part of your `context_settings`.'
             )
 
     @abc.abstractmethod
@@ -138,12 +139,12 @@ class Constraint(abc.ABC):
         from ._support import ConstraintMixin
 
         if not params:
-            raise ValueError("arg 'params' can't be empty")
+            raise ValueError("argument `params` can't be empty")
 
         ctx = click.get_current_context() if ctx is None else ctx
         if not isinstance(ctx.command, ConstraintMixin):  # this is needed for mypy
             raise TypeError('constraints work only if the command inherits from '
-                            'ConstraintMixin')
+                            '`ConstraintMixin`')
 
         if isinstance(params[0], str):
             param_names = cast(Sequence[str], params)

--- a/cloup/constraints/common.py
+++ b/cloup/constraints/common.py
@@ -33,9 +33,9 @@ def get_param_name(param: Parameter) -> str:
     """
     if param.name is None:
         raise TypeError(
-            'param.name is required to be a string in this context.\n'
-            'Hint: param.name is None only when parameter.expose_value is False, '
-            'so you are probably using such option incorrectly.'
+            '`param.name` is required to be a string in this context.\n'
+            'Hint: `param.name` is None only when `parameter.expose_value` is False, '
+            'so you are probably using this option incorrectly.'
         )
     return param.name
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -9,11 +9,11 @@ from tests.util import new_dummy_func
 
 
 def test_command_handling_of_unknown_argument():
-    with pytest.raises(TypeError, match='HINT: you set cls='):
+    with pytest.raises(TypeError, match='Hint: you set `cls='):
         cloup.command(cls=click.Command, align_option_groups=True)(new_dummy_func())
     with pytest.raises(TypeError, match='nonexisting') as info:
         cloup.command(nonexisting=True)(new_dummy_func())
-    assert re.search(str(info.value), 'HINT') is None
+    assert re.search(str(info.value), 'Hint') is None
 
 
 def test_group_raises_if_cls_is_not_subclass_of_click_Group():
@@ -25,11 +25,11 @@ def test_group_raises_if_cls_is_not_subclass_of_click_Group():
 
 
 def test_group_handling_of_unknown_argument():
-    with pytest.raises(TypeError, match='HINT'):
+    with pytest.raises(TypeError, match='Hint'):
         cloup.group(cls=click.Group, align_sections=True)(new_dummy_func())
     with pytest.raises(TypeError) as info:
         cloup.group(unexisting_arg=True)(new_dummy_func())
-    assert re.search(str(info.value), 'HINT') is None
+    assert re.search(str(info.value), 'Hint') is None
 
 
 def test_command_works_with_no_parameters(runner):

--- a/tests/test_option_groups.py
+++ b/tests/test_option_groups.py
@@ -16,7 +16,7 @@ from tests.util import (make_options, new_dummy_func, parametrize, pick_first_bo
 
 def test_error_message_if_first_arg_is_not_a_string():
     with pytest.raises(
-        TypeError, match="the first argument of @option_group must be its title"
+        TypeError, match="the first argument of `@option_group` must be its title"
     ):
         @option_group(
             option('--one'),


### PR DESCRIPTION
This attempts to standardize error message by following these conventions (which are very standard, as I understand):
- Begin with lower-case letters
- Do not end with punctuation, if only one sentence
- Enclose all references to variables and types in backticks

I also made a few minor fixes to grammar.

Hope this is alright. Let me know if you have any questions about what I changed!