### PR TITLE
Use wcwidth package for measuring displayed text width

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 .DEFAULT_GOAL := help
 
-REMOVE = python scripts/remove.py
-BROWSER = python scripts/browser.py
-COPYTREE = python scripts/copytree.py
+REMOVE = python3 scripts/remove.py
+BROWSER = python3 scripts/browser.py
+COPYTREE = python3 scripts/copytree.py
 
 DOCS_HTML_DIR = docs/_build/html
 DOCS_HTML_STATIC = $(DOCS_HTML_DIR)/_static
 
 .PHONY: help
 help:
-	@python scripts/make-help.py < $(MAKEFILE_LIST)
+	@python3 scripts/make-help.py < $(MAKEFILE_LIST)
 
 .PHONY: venv
 venv: ## creates a virtualenv using tox
@@ -97,7 +97,7 @@ clean-test: ## remove test and coverage artifacts
 
 .PHONY: dist
 dist: clean-build ## builds source and wheel package
-	python setup.py sdist bdist_wheel
+	python3 setup.py sdist bdist_wheel
 	twine check dist/*
 
 .PHONY: release
@@ -116,7 +116,7 @@ pip-compile:  ## pin dependencies in requirements/ using the current env
 
 .PHONY: pip-upgrade
 pip-upgrade:   ## upgrade pip and dependencies
-	python -m pip install -U pip
+	python3 -m pip install -U pip
 	pip-compile --upgrade requirements/test.in
 	pip-compile --upgrade requirements/docs.in
 	pip-compile --upgrade requirements/dev.in

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 .DEFAULT_GOAL := help
 
-REMOVE = python3 scripts/remove.py
-BROWSER = python3 scripts/browser.py
-COPYTREE = python3 scripts/copytree.py
+REMOVE = python scripts/remove.py
+BROWSER = python scripts/browser.py
+COPYTREE = python scripts/copytree.py
 
 DOCS_HTML_DIR = docs/_build/html
 DOCS_HTML_STATIC = $(DOCS_HTML_DIR)/_static
 
 .PHONY: help
 help:
-	@python3 scripts/make-help.py < $(MAKEFILE_LIST)
+	@python scripts/make-help.py < $(MAKEFILE_LIST)
 
 .PHONY: venv
 venv: ## creates a virtualenv using tox
@@ -97,7 +97,7 @@ clean-test: ## remove test and coverage artifacts
 
 .PHONY: dist
 dist: clean-build ## builds source and wheel package
-	python3 setup.py sdist bdist_wheel
+	python setup.py sdist bdist_wheel
 	twine check dist/*
 
 .PHONY: release
@@ -116,7 +116,7 @@ pip-compile:  ## pin dependencies in requirements/ using the current env
 
 .PHONY: pip-upgrade
 pip-upgrade:   ## upgrade pip and dependencies
-	python3 -m pip install -U pip
+	python -m pip install -U pip
 	pip-compile --upgrade requirements/test.in
 	pip-compile --upgrade requirements/docs.in
 	pip-compile --upgrade requirements/dev.in

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@
 
 .. |coverage| image:: https://codecov.io/github/janLuke/cloup/coverage.svg?branch=master
     :alt: Coverage Status
-    :target: https://codecov.io/github/janLuke/cloup?branch=master
+    :target: https://app.codecov.io/github/janluke/cloup/tree/master
 
 .. |python-versions| image:: https://img.shields.io/pypi/pyversions/cloup.svg
     :alt: Supported versions

--- a/cloup/formatting/__init__.py
+++ b/cloup/formatting/__init__.py
@@ -5,7 +5,7 @@ from ._formatter import (
 from ._util import (
     ensure_is_cloup_formatter,
     display_width,
-    display_width_unstyled,
+    unstyled_len,
 )
 
 __all__ = [
@@ -13,5 +13,5 @@ __all__ = [
     "HelpSection",
     "ensure_is_cloup_formatter",
     "display_width",
-    "display_width_unstyled",
+    "unstyled_len",
 ]

--- a/cloup/formatting/__init__.py
+++ b/cloup/formatting/__init__.py
@@ -4,12 +4,14 @@ from ._formatter import (
 )
 from ._util import (
     ensure_is_cloup_formatter,
-    unstyled_len,
+    display_width,
+    display_width_unstyled,
 )
 
 __all__ = [
     "HelpFormatter",
     "HelpSection",
     "ensure_is_cloup_formatter",
-    "unstyled_len",
+    "display_width",
+    "display_width_unstyled",
 ]

--- a/cloup/formatting/_formatter.py
+++ b/cloup/formatting/_formatter.py
@@ -9,7 +9,7 @@ from typing import (
 )
 
 from cloup._util import click_version_ge_8_1
-from cloup.formatting._util import display_width, display_width_unstyled
+from cloup.formatting._util import display_width
 
 if TYPE_CHECKING:
     from .sep import RowSepPolicy, SepGenerator
@@ -247,7 +247,7 @@ class HelpFormatter(click.HelpFormatter):
         self.write(wrapped_text, "\n")
 
     def compute_col1_width(self, rows: Iterable[Definition], max_width: int) -> int:
-        col1_lengths = (display_width_unstyled(r[0]) for r in rows)
+        col1_lengths = (display_width(r[0]) for r in rows)
         lengths_under_limit = (length for length in col1_lengths if length <= max_width)
         return max(lengths_under_limit, default=0)
 
@@ -346,9 +346,9 @@ class HelpFormatter(click.HelpFormatter):
             if not second:
                 self.write("\n")
             else:
-                first_display_length = display_width_unstyled(first)
-                if first_display_length <= col1_width:
-                    spaces_to_col2 = col1_plus_spacing - first_display_length
+                first_display_width = display_width(first)
+                if first_display_width <= col1_width:
+                    spaces_to_col2 = col1_plus_spacing - first_display_width
                     self.write(" " * spaces_to_col2)
                 else:
                     self.write("\n", col2_indentation)

--- a/cloup/formatting/_formatter.py
+++ b/cloup/formatting/_formatter.py
@@ -220,9 +220,9 @@ class HelpFormatter(click.HelpFormatter):
         self.write("\n")
         self.write_heading(s.heading, newline=not s.constraint)
         if s.constraint:
-            constraint_text = f'[{s.constraint}]'
+            constraint_text = f"[{s.constraint}]"
             available_width = (
-                self.available_width - display_width(s.heading) - display_width(': '))
+                self.available_width - display_width(s.heading) - len(": "))
             if display_width(constraint_text) <= available_width:
                 self.write(" ", theme.constraint(constraint_text), "\n")
             else:

--- a/cloup/formatting/_formatter.py
+++ b/cloup/formatting/_formatter.py
@@ -9,7 +9,7 @@ from typing import (
 )
 
 from cloup._util import click_version_ge_8_1
-from cloup.formatting._util import unstyled_len
+from cloup.formatting._util import display_width, display_width_unstyled
 
 if TYPE_CHECKING:
     from .sep import RowSepPolicy, SepGenerator
@@ -21,8 +21,9 @@ from cloup._util import (
     check_positive_int, identity, indent_lines, make_repr,
     pick_non_missing,
 )
-from ..typing import MISSING, Possibly
 from cloup.styling import HelpTheme, IStyle
+
+from ..typing import MISSING, Possibly
 
 Definition = Tuple[str, Union[str, Callable[[int], str]]]
 
@@ -220,8 +221,9 @@ class HelpFormatter(click.HelpFormatter):
         self.write_heading(s.heading, newline=not s.constraint)
         if s.constraint:
             constraint_text = f'[{s.constraint}]'
-            available_width = self.available_width - len(s.heading) - len(': ')
-            if len(constraint_text) <= available_width:
+            available_width = (
+                self.available_width - display_width(s.heading) - display_width(': '))
+            if display_width(constraint_text) <= available_width:
                 self.write(" ", theme.constraint(constraint_text), "\n")
             else:
                 self.write("\n")
@@ -245,7 +247,7 @@ class HelpFormatter(click.HelpFormatter):
         self.write(wrapped_text, "\n")
 
     def compute_col1_width(self, rows: Iterable[Definition], max_width: int) -> int:
-        col1_lengths = (unstyled_len(r[0]) for r in rows)
+        col1_lengths = (display_width_unstyled(r[0]) for r in rows)
         lengths_under_limit = (length for length in col1_lengths if length <= max_width)
         return max(lengths_under_limit, default=0)
 
@@ -344,14 +346,14 @@ class HelpFormatter(click.HelpFormatter):
             if not second:
                 self.write("\n")
             else:
-                first_display_length = unstyled_len(first)
+                first_display_length = display_width_unstyled(first)
                 if first_display_length <= col1_width:
                     spaces_to_col2 = col1_plus_spacing - first_display_length
                     self.write(" " * spaces_to_col2)
                 else:
                     self.write("\n", col2_indentation)
 
-                if len(second) <= col2_width:
+                if display_width(second) <= col2_width:
                     self.write(col2_styler(second), "\n")
                 else:
                     wrapped_text = wrap_text(second, col2_width, preserve_paragraphs=True)

--- a/cloup/formatting/_util.py
+++ b/cloup/formatting/_util.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import TYPE_CHECKING, cast
 
 import click
@@ -25,8 +26,12 @@ def ensure_is_cloup_formatter(formatter: click.HelpFormatter) -> 'cloup.HelpForm
 
 
 def display_width(string: str) -> int:
-    return cast(int, wcswidth(string))
+    return cast(int, wcswidth(click.unstyle(string)))
 
 
-def display_width_unstyled(string: str) -> int:
-    return display_width(click.unstyle(string))
+def unstyled_len(string: str) -> int:
+    warnings.warn(
+        "`unstyled_len()` is deprecated; use `display_width()` instead",
+        DeprecationWarning
+    )
+    return len(click.unstyle(string))

--- a/cloup/formatting/_util.py
+++ b/cloup/formatting/_util.py
@@ -1,6 +1,7 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import click
+from wcwidth import wcswidth
 
 if TYPE_CHECKING:
     import cloup
@@ -23,5 +24,9 @@ def ensure_is_cloup_formatter(formatter: click.HelpFormatter) -> 'cloup.HelpForm
     raise TypeError(FORMATTER_TYPE_ERROR)
 
 
-def unstyled_len(string: str) -> int:
-    return len(click.unstyle(string))
+def display_width(string: str) -> int:
+    return cast(int, wcswidth(string))
+
+
+def display_width_unstyled(string: str) -> int:
+    return display_width(click.unstyle(string))

--- a/cloup/formatting/sep.py
+++ b/cloup/formatting/sep.py
@@ -10,6 +10,8 @@ import sys
 from itertools import zip_longest
 from typing import Optional, Sequence, Union
 
+from ._util import display_width
+
 if sys.version_info[:2] >= (3, 8):
     from typing import Protocol
 else:  # pragma: no cover
@@ -128,7 +130,7 @@ def count_multiline_rows(rows: Sequence[Sequence[str]], col_widths: Sequence[int
     # if len(row) != len(col_widths). An explicit check is not worth it since
     # this should never happen.
     return sum(
-        any(len(col_text) > col_width
+        any(display_width(col_text) > col_width
             for col_text, col_width in zip_longest(row, col_widths))
         for row in rows
     )
@@ -206,9 +208,10 @@ class Hline(SepGenerator):
 
     def __call__(self, width: int) -> str:
         pattern = self.pattern
-        if len(pattern) == 1:
+        pattern_width = display_width(pattern)
+        if pattern_width == 1:
             return pattern * width
-        reps, rest = width // len(pattern), width % len(pattern)
+        reps, rest = width // pattern_width, width % pattern_width
         return pattern * reps + pattern[:rest]
 
 

--- a/docs/pages/constraints.rst
+++ b/docs/pages/constraints.rst
@@ -316,7 +316,7 @@ is equivalent to:
 
     In Python < 3.9, the expression on the right of the operator ``@``
     is required to be a "dotted name, optionally followed by a single call"
-    (see `PEP 614 <https://www.python.org/dev/peps/pep-0614/#motivation>`_).
+    (see `PEP 614 <https://peps.python.org/pep-0614/#motivation>`_).
     This means that you can't instantiate a parametric constraint on the right
     of ``@``, because the resultant expressions would make two calls, e.g.:
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,8 @@ setup(
     include_package_data=True,
     python_requires='>=3.7',
     install_requires=[
-        'click >= 8.0, < 9.0',
+        'click ~= 8.0',
+        'wcwidth ~= 0.2.5',
         'typing_extensions; python_version<="3.8"',
     ],
 )

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -10,7 +10,7 @@ import pytest
 
 from cloup import HelpFormatter
 from cloup.typing import Possibly
-from cloup.formatting import HelpSection, display_width, display_width_unstyled
+from cloup.formatting import HelpSection, display_width
 from cloup.formatting.sep import (
     Hline, RowSepIf, RowSepPolicy, multiline_rows_are_at_least
 )
@@ -207,7 +207,7 @@ def test_write_text_with_styles():
     formatter.write_text(INPUT_TEXT, style=style)
     actual = formatter.getvalue().rstrip()
     for line in actual.splitlines():
-        assert display_width_unstyled(line) <= formatter.width
+        assert display_width(line) <= formatter.width
     assert actual == EXPECTED
 
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -10,7 +10,7 @@ import pytest
 
 from cloup import HelpFormatter
 from cloup.typing import Possibly
-from cloup.formatting import HelpSection, unstyled_len
+from cloup.formatting import HelpSection, display_width, display_width_unstyled
 from cloup.formatting.sep import (
     Hline, RowSepIf, RowSepPolicy, multiline_rows_are_at_least
 )
@@ -26,7 +26,7 @@ ROWS = [
 
 
 def test_write_dl_with_col1_max_width_equal_to_longest_col1_value():
-    formatter = HelpFormatter(width=80, col1_max_width=len(ROWS[0][0]))
+    formatter = HelpFormatter(width=80, col1_max_width=display_width(ROWS[0][0]))
     formatter.current_indent = 4
     expected = """
     -l, --long-option-name TEXT  Lorem ipsum dolor sit amet, consectetur
@@ -41,7 +41,7 @@ def test_write_dl_with_col1_max_width_equal_to_longest_col1_value():
 
 
 def test_formatter_excludes_rows_exceeding_col1_max_width_from_col1_width_computation():
-    formatter = HelpFormatter(width=80, col1_max_width=len('--short'))
+    formatter = HelpFormatter(width=80, col1_max_width=display_width('--short'))
     formatter.current_indent = 4
     expected = """
     -l, --long-option-name TEXT
@@ -61,7 +61,7 @@ def test_col2_min_width():
     formatter = HelpFormatter(width=80)
     formatter.current_indent = 4
     formatter.col2_min_width = (
-        formatter.available_width - len(ROWS[0][0]) - formatter.col_spacing)
+        formatter.available_width - display_width(ROWS[0][0]) - formatter.col_spacing)
     expected = """
     -l, --long-option-name TEXT  Lorem ipsum dolor sit amet, consectetur
                                  adipiscing elit, sed do eiusmod tempor.
@@ -207,7 +207,7 @@ def test_write_text_with_styles():
     formatter.write_text(INPUT_TEXT, style=style)
     actual = formatter.getvalue().rstrip()
     for line in actual.splitlines():
-        assert unstyled_len(line) <= formatter.width
+        assert display_width_unstyled(line) <= formatter.width
     assert actual == EXPECTED
 
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -231,3 +231,25 @@ def test_write_section_print_long_constraint_on_a_new_line():
     formatter.write_section(section)
     actual = formatter.getvalue()
     assert actual == expected
+
+
+def test_display_width():
+    rows = [
+        # `✔️` char has length of 2 but display width of 1
+        ('-l, --long-option-name TEXT✔️', LOREM),
+        ('--another-option INT', LOREM),
+        ('--short', LOREM),
+    ]
+
+    formatter = HelpFormatter(width=80)
+    formatter.current_indent = 4
+    expected = """
+    -l, --long-option-name TEXT✔️  Lorem ipsum dolor sit amet, consectetur
+                                  adipiscing elit, sed do eiusmod tempor.
+    --another-option INT          Lorem ipsum dolor sit amet, consectetur
+                                  adipiscing elit, sed do eiusmod tempor.
+    --short                       Lorem ipsum dolor sit amet, consectetur
+                                  adipiscing elit, sed do eiusmod tempor.
+    """[1:-4]
+    formatter.write_dl(rows)
+    assert formatter.getvalue() == expected


### PR DESCRIPTION
When calculating layout for displaying text in the terminal, it's important to use `wcwidth` instead of `len` in general because not all Unicode characters have width one. This includes certain symbolic characters (like emojis), which previously made a mess of the alignment calculations.

## Deprecation
**(janluke edit)** With this PR, the utility function `unstyled_len` is deprecated. Use `display_width` instead, which is similar but uses `wcwidth`.