### PR TITLE
Feature: theming support for list of subcommand aliases

### DIFF
--- a/cloup/_commands.py
+++ b/cloup/_commands.py
@@ -36,6 +36,7 @@ from ._option_groups import OptionGroupMixin
 from ._sections import Section, SectionMixin
 from ._util import click_version_ge_8_1, first_bool, reindent
 from .constraints import ConstraintMixin
+from .styling import DEFAULT_THEME
 from .typing import AnyCallable
 
 ClickCommand = TypeVar('ClickCommand', bound=click.Command)
@@ -227,8 +228,15 @@ class Group(SectionMixin, Command, click.Group):
     ) -> str:
         aliases = getattr(cmd, 'aliases', None)
         if aliases and self.must_show_subcommand_aliases(ctx):
-            alias_list = ', '.join(aliases)
-            return f"{name} ({alias_list})"
+            assert isinstance(ctx, cloup.Context)
+            theme = cast(
+                cloup.HelpTheme, ctx.formatter_settings.get("theme", DEFAULT_THEME)
+            )
+            alias_style, sep_style, boundary_style = theme.alias_list_styles
+            alias_list = sep_style(", ").join(alias_style(alias) for alias in aliases)
+            open_par = boundary_style("(")
+            close_par = boundary_style(")")
+            return f"{name} {open_par}{alias_list}{close_par}"
         return name
 
     # MyPy complains because "Signature of "group" incompatible with supertype".

--- a/cloup/_commands.py
+++ b/cloup/_commands.py
@@ -24,8 +24,8 @@ When and if the MyPy issue is resolved, the overloads will be removed.
 """
 import inspect
 from typing import (
-    Any, Callable, Dict, Iterable, List, NamedTuple, Optional, Tuple, Type,
-    TypeVar, Union, cast, overload,
+    Any, Callable, Dict, Iterable, List, NamedTuple, Optional, Sequence, Tuple,
+    Type, TypeVar, Union, cast, overload,
 )
 
 import click
@@ -232,12 +232,21 @@ class Group(SectionMixin, Command, click.Group):
             theme = cast(
                 cloup.HelpTheme, ctx.formatter_settings.get("theme", DEFAULT_THEME)
             )
-            alias_style, sep_style, boundary_style = theme.alias_list_styles
-            alias_list = sep_style(", ").join(alias_style(alias) for alias in aliases)
-            open_par = boundary_style("(")
-            close_par = boundary_style(")")
-            return f"{name} {open_par}{alias_list}{close_par}"
+            alias_list = self.format_subcommand_aliases(aliases, theme)
+            return f"{name} {alias_list}"
         return name
+
+    @staticmethod
+    def format_subcommand_aliases(aliases: Sequence[str], theme: cloup.HelpTheme) -> str:
+        secondary_style = theme.alias_secondary
+        if secondary_style is None or secondary_style == theme.alias:
+            return theme.alias(f"({', '.join(aliases)})")
+        else:
+            return (
+                secondary_style("(")
+                + secondary_style(", ").join(theme.alias(alias) for alias in aliases)
+                + secondary_style(")")
+            )
 
     # MyPy complains because "Signature of "group" incompatible with supertype".
     # The supertype signature is (*args, **kwargs), which is compatible with

--- a/cloup/styling.py
+++ b/cloup/styling.py
@@ -103,6 +103,8 @@ class HelpTheme(NamedTuple):
             heading=Style(fg='bright_white', bold=True),
             constraint=Style(fg='magenta'),
             col1=Style(fg='bright_yellow'),
+            alias=Style(fg='yellow'),
+            alias_secondary=Style(fg='white'),
         )
 
     @staticmethod

--- a/cloup/styling.py
+++ b/cloup/styling.py
@@ -3,7 +3,7 @@ This module contains components that specifically address the styling and themin
 of the ``--help`` output.
 """
 import dataclasses as dc
-from typing import Any, Callable, Dict, NamedTuple, Optional
+from typing import Any, Callable, Dict, NamedTuple, Optional, Tuple
 
 import click
 
@@ -62,8 +62,25 @@ class HelpTheme(NamedTuple):
     col2: IStyle = identity
     """Style of the second column of a definition list (help text)."""
 
+    alias: IStyle = identity
+    """Style of command aliases in a definition list."""
+
+    alias_list_sep: Optional[IStyle] = None
+    """Style of separator and eventual parenthesis/brackets in command alias lists.
+    If not provided, ``col1`` style will be used."""
+
+    alias_list_boundaries: Optional[IStyle] = None
+    """Style of the boundary characters (parenthesis by default) of a command alias list.
+    If not provided, ``alias_list_sep`` will be used."""
+
     epilog: IStyle = identity
     """Style of the epilog."""
+
+    @property
+    def alias_list_styles(self) -> Tuple[IStyle, IStyle, IStyle]:
+        sep_style = self.alias_list_sep or self.col1
+        boundary_style = self.alias_list_boundaries or sep_style
+        return self.alias, sep_style, boundary_style
 
     def with_(
         self, invoked_command: Optional[IStyle] = None,
@@ -73,6 +90,9 @@ class HelpTheme(NamedTuple):
         section_help: Optional[IStyle] = None,
         col1: Optional[IStyle] = None,
         col2: Optional[IStyle] = None,
+        alias: Optional[IStyle] = None,
+        alias_list_sep: Optional[IStyle] = None,
+        alias_list_boundaries: Optional[IStyle] = None,
         epilog: Optional[IStyle] = None,
     ) -> 'HelpTheme':
         kwargs = {key: val for key, val in locals().items() if val is not None}
@@ -184,3 +204,6 @@ class Color(FrozenSpace):
     bright_magenta = "bright_magenta"
     bright_cyan = "bright_cyan"
     bright_white = "bright_white"
+
+
+DEFAULT_THEME = HelpTheme()

--- a/examples/manim/main.py
+++ b/examples/manim/main.py
@@ -41,6 +41,8 @@ CONTEXT_SETTINGS = Context.settings(
             # col1=Style(...),
             col2=Style(dim=True),
             epilog=Style(fg=Color.bright_white, italic=True),
+            alias=Style(fg=Color.yellow),
+            alias_list_sep=Style(fg=Color.white, dim=True),
         ),
     ),
 )

--- a/examples/manim/main.py
+++ b/examples/manim/main.py
@@ -42,7 +42,7 @@ CONTEXT_SETTINGS = Context.settings(
             col2=Style(dim=True),
             epilog=Style(fg=Color.bright_white, italic=True),
             alias=Style(fg=Color.yellow),
-            alias_list_sep=Style(fg=Color.white, dim=True),
+            alias_secondary=Style(fg=Color.white),
         ),
     ),
 )

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -1,9 +1,12 @@
+from typing import Optional
+
 import click
 import pytest
 
 import cloup
-from cloup import Group
-from cloup._util import first_bool, reindent
+from cloup import Color, Group, HelpTheme, Style
+from cloup._util import first_bool, identity, reindent
+from cloup.styling import IStyle
 from cloup.typing import MISSING
 
 
@@ -168,3 +171,28 @@ def test_cloup_subgroup_help(cli, runner):
           --help  Show this message and exit.
     """)
     assert res.output == expected
+
+
+def test_alias_are_correctly_styled(runner):
+    red = Style(fg=Color.red)
+    green = Style(fg=Color.green)
+
+    def fmt(alias: IStyle = identity, alias_secondary: Optional[IStyle] = None):
+        theme = HelpTheme(alias=alias, alias_secondary=alias_secondary)
+        return Group.format_subcommand_aliases(["i", "add"], theme)
+
+    # No styles (default theme)
+    assert fmt() == "(i, add)"
+
+    # Only theme.alias
+    assert fmt(alias=green) == f"{green('(i, add)')}"
+
+    # Only theme.alias_secondary
+    assert fmt(alias_secondary=green) == (
+        green("(") + "i" + green(", ") + "add" + green(")")
+    )
+
+    # Both
+    assert fmt(alias=red, alias_secondary=green) == (
+        green("(") + red("i") + green(", ") + red("add") + green(")")
+    )

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -9,12 +9,12 @@ import click
 import pytest
 
 from cloup import HelpFormatter
-from cloup.typing import Possibly
 from cloup.formatting import HelpSection, unstyled_len
 from cloup.formatting.sep import (
     Hline, RowSepIf, RowSepPolicy, multiline_rows_are_at_least
 )
 from cloup.styling import HelpTheme, Style
+from cloup.typing import Possibly
 from tests.util import parametrize
 
 LOREM = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor."


### PR DESCRIPTION
This PR adds two new styles to `HelpTheme` which affects a `Group` subcommands definition list:
- `alias`: color of a subcommand alias names
- `alias_secondary`: color of separator (comma) and parenthesis in subcommand alias lists.

If `alias_secondary` is not provided, `alias` style is used.

This PR changes the dark theme so that aliases are shown in "yellow" (col1 is bright yellow) and `alias_secondary` is just normal white.

Closes #151.

---
## Old, previous iteration

This PR adds three styles to `HelpTheme`:
- `alias`: color of alias
- `alias_list_sep`: color of alias separators (i.e. "," by default)
- `alias_list_boundaries`: color of eventual characters "wrapping" the list of alias (i.e. parenthesis by default).

The last two might not be specified. In such case:
- `col1` will be used for `alias_list_sep`
- whatever is used for `alias_list_sep` will be used for boundaries (i.e. `alias_list_sep` or `col1`).

Remember you can always use override `Command.format_subcommand_aliases` to customize how aliases are formatted.

@wabiloo

