### PR TITLE
Use the same `(Deprecated)` label as in Click

### DIFF
--- a/cloup/formatting/_formatter.py
+++ b/cloup/formatting/_formatter.py
@@ -185,7 +185,9 @@ class HelpFormatter(click.HelpFormatter):
         if help_text and click_version_ge_8_1:
             help_text = inspect.cleandoc(help_text)
         if cmd.deprecated:
-            help_text = "(DEPRECATED) " + help_text
+            # Use the same label as Click:
+            # https://github.com/pallets/click/blob/b0538df/src/click/core.py#L1331
+            help_text = "(Deprecated) " + help_text
         if help_text:
             self.write_paragraph()
             with self.indentation():


### PR DESCRIPTION
Just a little nit-pick, but to have consistent output, I propose to change the case of the deprecated label from commands, and aligns it to Click's.

See Click's code at: https://github.com/pallets/click/blob/b0538df/src/click/core.py#L1331

For the record, this has been changed [from `(DEPRECATED)`](https://github.com/pallets/click/commit/0786fda333610aa04c912b17d81f2784bf54ba50#diff-11ba83cac151f7b24a1ed7c31a2a522d24d190cfa43199aa478d1e9cd2e6c610L43) to the current `(Deprecated)` [in Click  in `8.0.0rc1`](https://github.com/pallets/click/commit/0786fda333610aa04c912b17d81f2784bf54ba50#diff-11ba83cac151f7b24a1ed7c31a2a522d24d190cfa43199aa478d1e9cd2e6c610L43). Also see: https://github.com/pallets/click/pull/1816.