### PR TITLE
Fix `write_usage`: formatting and default value

### DIFF
--- a/cloup/formatting/_formatter.py
+++ b/cloup/formatting/_formatter.py
@@ -168,10 +168,10 @@ class HelpFormatter(click.HelpFormatter):
         self.buffer += strings
 
     def write_usage(
-        self, prog: str, args: str = "", prefix: Optional[str] = "Usage:"
+        self, prog: str, args: str = "", prefix: Optional[str] = None
     ) -> None:
-        if prefix:
-            prefix = self.theme.heading(prefix) + " "
+        prefix = "Usage:" if prefix is None else prefix
+        prefix = self.theme.heading(prefix) + " "
         prog = self.theme.invoked_command(prog)
         super().write_usage(prog, args, prefix)
 

--- a/cloup/formatting/_formatter.py
+++ b/cloup/formatting/_formatter.py
@@ -168,10 +168,10 @@ class HelpFormatter(click.HelpFormatter):
         self.buffer += strings
 
     def write_usage(
-        self, prog: str, args: str = "", prefix: Optional[str] = 'Usage:'
+        self, prog: str, args: str = "", prefix: Optional[str] = "Usage:"
     ) -> None:
         if prefix:
-            prefix = self.theme.heading(prefix + ' ')
+            prefix = self.theme.heading(prefix) + " "
         prog = self.theme.invoked_command(prog)
         super().write_usage(prog, args, prefix)
 


### PR DESCRIPTION
Fixes #157.
- #157

and another minor issue:
- set `prefix=None` by default, otherwise if the caller passes `None`, the heading doesn't get styled as expected.