### PR TITLE
Redefine `click.pass_context` and `click.get_current_context` to use `cloup.Context` in place of `click.Context`

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,6 +5,8 @@ on:
     tags: [v*]
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 7"
 
 jobs:
   tests:

--- a/cloup/__init__.py
+++ b/cloup/__init__.py
@@ -11,7 +11,6 @@ from click import (
     # decorators
     confirmation_option,
     help_option,
-    pass_context,
     pass_obj,
     password_option,
     version_option,
@@ -42,7 +41,7 @@ from .formatting import (
     HelpFormatter,
     HelpSection,
 )
-from ._context import Context
+from ._context import Context, pass_context
 from ._params import Argument, Option, argument, option
 from ._option_groups import (
     OptionGroup,

--- a/cloup/__init__.py
+++ b/cloup/__init__.py
@@ -41,7 +41,7 @@ from .formatting import (
     HelpFormatter,
     HelpSection,
 )
-from ._context import Context, pass_context
+from ._context import Context, get_current_context, pass_context
 from ._params import Argument, Option, argument, option
 from ._option_groups import (
     OptionGroup,
@@ -103,6 +103,7 @@ __all__ = [
     "constraint",
     "dir_path",
     "file_path",
+    "get_current_context",
     "group",
     "help_option",
     "option",

--- a/cloup/_context.py
+++ b/cloup/_context.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import warnings
-from typing import Any, Callable, Dict, List, Optional, Type
+from typing import Any, Callable, cast, Dict, List, Optional, Type, TypeVar, TYPE_CHECKING
+from functools import update_wrapper
 
 import click
 
@@ -222,3 +225,22 @@ class Context(click.Context):
             dictionary, so that you can be guided by your IDE.
         """
         return pick_non_missing(locals())
+
+
+if TYPE_CHECKING:
+    import typing_extensions as te
+
+    P = te.ParamSpec("P")
+
+R = TypeVar("R")
+
+
+def pass_context(f: Callable[te.Concatenate[Context, P], R]) -> Callable[P, R]:
+    """Marks a callback as wanting to receive the current context
+    object as first argument.
+    """
+
+    def new_func(*args: P.args, **kwargs: P.kwargs) -> R:
+        return f(cast(Context, click.get_current_context()), *args, **kwargs)
+
+    return update_wrapper(new_func, f)

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,9 @@ deps = flake8
 commands = flake8 cloup tests examples
 
 [testenv:mypy]
-deps = mypy
+deps =
+  mypy
+  typing-extensions
 commands =
   mypy --strict cloup
   mypy tests examples


### PR DESCRIPTION
This PR redefines `click.pass_context` and `click.get_current_context` so that the type of the returned `Context` object is `cloup.Context` and not `click.Context`.

I (@janluke)  used `@overload` to provide better type annotations for `cloup.get_current_context`: if the `silent` argument is not provided, the return type is `Context`, not `Optional[Context]`.