### PR TITLE
Fix: command alias were ignored when subcommands were passed as argument to `Group()`

### DIFF
--- a/cloup/_commands.py
+++ b/cloup/_commands.py
@@ -25,7 +25,7 @@ When and if the MyPy issue is resolved, the overloads will be removed.
 import inspect
 from typing import (
     Any, Callable, Dict, Iterable, List, NamedTuple, Optional, Sequence, Tuple,
-    Type, TypeVar, Union, cast, overload
+    Type, TypeVar, Union, cast, overload, MutableMapping, Mapping,
 )
 
 import click
@@ -143,7 +143,12 @@ class Group(SectionMixin, Command, click.Group):
     SHOW_SUBCOMMAND_ALIASES: bool = False
 
     def __init__(
-        self, *args: Any, show_subcommand_aliases: Optional[bool] = None, **kwargs: Any
+        self, *args: Any,
+        show_subcommand_aliases: Optional[bool] = None,
+        commands: Optional[
+            Union[MutableMapping[str, click.Command], Sequence[click.Command]]
+        ] = None,
+        **kwargs: Any
     ):
         super().__init__(*args, **kwargs)
         self.show_subcommand_aliases = show_subcommand_aliases
@@ -151,6 +156,19 @@ class Group(SectionMixin, Command, click.Group):
 
         self.alias2name: Dict[str, str] = {}
         """Dictionary mapping each alias to a command name."""
+
+        if commands:
+            self.add_multiple_commands(commands)
+
+    def add_multiple_commands(
+        self, commands: Union[Mapping[str, click.Command], Sequence[click.Command]]
+    ) -> None:
+        if isinstance(commands, Mapping):
+            for name, cmd in commands.items():
+                self.add_command(cmd, name=name)
+        else:
+            for cmd in commands:
+                self.add_command(cmd)
 
     def add_command(
         self, cmd: click.Command,

--- a/cloup/_sections.py
+++ b/cloup/_sections.py
@@ -146,7 +146,11 @@ class SectionMixin:
 
     def add_section(self, section: Section) -> None:
         """Add a :class:`Section` to this group. You can add the same
-        section object a single time."""
+        section object only a single time.
+
+        See Also:
+            :meth:`section`
+        """
         if section in self._section_set:
             raise ValueError(f'section "{section}" was already added')
         self._user_sections.append(section)

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -10,12 +10,8 @@ from cloup.styling import IStyle
 from cloup.typing import MISSING
 
 
-@pytest.fixture()
-def cli() -> cloup.Group:
-    @cloup.group()
-    def cli():
-        """A package installer."""
-
+@pytest.fixture(params=["section", "init_arg"])
+def cli(request) -> cloup.Group:
     @cloup.command(aliases=['i', 'add'])
     @cloup.argument('pkg')
     def install(pkg: str):
@@ -32,7 +28,23 @@ def cli() -> cloup.Group:
         """Remove all installed packages."""
         print('clear')
 
-    cli.section('Commands', install, clear, config)
+    if request.param == "section":
+        @cloup.group()
+        def cli():
+            """A package installer."""
+
+        cli.section("Commands", install, clear, config, is_sorted=True)
+
+    elif request.param == "init_arg":
+        cli = Group(
+            name="cli",
+            help="A package installer.",
+            commands=[install, clear, config],
+        )
+
+    else:
+        raise ValueError(request.param)
+
     return cli
 
 
@@ -45,9 +57,9 @@ cli_help_without_aliases = reindent("""
       --help  Show this message and exit.
 
     Commands:
-      install  Install a package.
       clear    Remove all installed packages.
       config   Manage the configuration.
+      install  Install a package.
 """)
 
 cli_help_with_aliases = reindent("""
@@ -59,9 +71,9 @@ cli_help_with_aliases = reindent("""
       --help  Show this message and exit.
 
     Commands:
-      install (i, add)    Install a package.
       clear (clr)         Remove all installed packages.
       config (conf, cfg)  Manage the configuration.
+      install (i, add)    Install a package.
 """)
 
 


### PR DESCRIPTION
Fixes #172.
- #172