### PR TITLE
Fix typo, ATTTRIBUTES -> ATTRIBUTES

### DIFF
--- a/docs/_autoapi_templates/python/module.rst
+++ b/docs/_autoapi_templates/python/module.rst
@@ -87,7 +87,7 @@ Functions
 {% endif %}
 {% endblock %}
 
-{# === ATTTRIBUTES SUMMARY === #}
+{# === ATTRIBUTES SUMMARY === #}
 {% block attributes scoped %}
 {% if visible_attributes %}
 Attributes


### PR DESCRIPTION
Found via `codespell -S cloup,requirements,venv`