### PR TITLE
click 8.2: `make_metavar()` takes a context parameter now

### DIFF
--- a/cloup/_option_groups.py
+++ b/cloup/_option_groups.py
@@ -11,7 +11,7 @@ from click import Option, Parameter
 
 import cloup
 from cloup._params import option
-from cloup._util import first_bool, make_repr
+from cloup._util import click_version_ge_8_2, first_bool, make_repr
 from cloup.constraints import Constraint
 from cloup.formatting import HelpSection, ensure_is_cloup_formatter
 from cloup.typing import Decorator, F
@@ -188,7 +188,14 @@ class OptionGroupMixin:
     ) -> Tuple[str, str]:
         if isinstance(arg, cloup.Argument):
             return arg.get_help_record(ctx)
-        return arg.make_metavar(), ""
+        return (
+            (
+                arg.make_metavar(ctx)  # type: ignore[call-arg]
+                if click_version_ge_8_2
+                else arg.make_metavar()
+            ),
+            "",
+        )
 
     def get_arguments_help_section(self, ctx: click.Context) -> Optional[HelpSection]:
         args_with_help = (arg for arg in self.arguments if getattr(arg, "help", None))

--- a/cloup/_option_groups.py
+++ b/cloup/_option_groups.py
@@ -10,8 +10,8 @@ import click
 from click import Option, Parameter
 
 import cloup
-from cloup._params import option
-from cloup._util import click_version_ge_8_2, first_bool, make_repr
+from cloup._params import option, make_arg_metavar
+from cloup._util import first_bool, make_repr
 from cloup.constraints import Constraint
 from cloup.formatting import HelpSection, ensure_is_cloup_formatter
 from cloup.typing import Decorator, F
@@ -188,14 +188,7 @@ class OptionGroupMixin:
     ) -> Tuple[str, str]:
         if isinstance(arg, cloup.Argument):
             return arg.get_help_record(ctx)
-        return (
-            (
-                arg.make_metavar(ctx)  # type: ignore[call-arg]
-                if click_version_ge_8_2
-                else arg.make_metavar()
-            ),
-            "",
-        )
+        return make_arg_metavar(arg, ctx), ""
 
     def get_arguments_help_section(self, ctx: click.Context) -> Optional[HelpSection]:
         args_with_help = (arg for arg in self.arguments if getattr(arg, "help", None))

--- a/cloup/_params.py
+++ b/cloup/_params.py
@@ -4,6 +4,12 @@ from click.decorators import _param_memo
 from cloup._util import click_version_ge_8_2
 
 
+def make_arg_metavar(arg, ctx) -> str:
+    if click_version_ge_8_2:
+        return arg.make_metavar(ctx)  # type: ignore[call-arg]
+    return arg.make_metavar()  # type: ignore[call-arg]
+
+
 class Argument(click.Argument):
     """A :class:`click.Argument` with help text."""
 
@@ -12,10 +18,7 @@ class Argument(click.Argument):
         self.help = help
 
     def get_help_record(self, ctx):
-        return (
-            (self.make_metavar(ctx) if click_version_ge_8_2 else self.make_metavar()),
-            self.help or "",
-        )
+        return make_arg_metavar(self, ctx), self.help or ""
 
 
 class Option(click.Option):

--- a/cloup/_params.py
+++ b/cloup/_params.py
@@ -1,6 +1,8 @@
 import click
 from click.decorators import _param_memo
 
+from cloup._util import click_version_ge_8_2
+
 
 class Argument(click.Argument):
     """A :class:`click.Argument` with help text."""
@@ -10,7 +12,10 @@ class Argument(click.Argument):
         self.help = help
 
     def get_help_record(self, ctx):
-        return self.make_metavar(), self.help or ""
+        return (
+            (self.make_metavar(ctx) if click_version_ge_8_2 else self.make_metavar()),
+            self.help or "",
+        )
 
 
 class Option(click.Option):

--- a/cloup/_params.pyi
+++ b/cloup/_params.pyi
@@ -21,6 +21,10 @@ ShellCompleteArg = Callable[
 ]
 
 
+def make_arg_metavar(arg: click.Argument, ctx: click.Context) -> str:
+    ...
+
+
 class Argument(click.Argument):
     def __init__(self, *args: Any, help: Optional[str] = None, **attrs: Any):
         ...

--- a/cloup/_util.py
+++ b/cloup/_util.py
@@ -11,6 +11,7 @@ click_version_tuple = tuple(click.__version__.split('.'))
 click_major = int(click_version_tuple[0])
 click_minor = int(click_version_tuple[1])
 click_version_ge_8_1 = (click_major, click_minor) >= (8, 1)
+click_version_ge_8_2 = (click_major, click_minor) >= (8, 2)
 
 T = TypeVar('T')
 K = TypeVar('K', bound=Hashable)


### PR DESCRIPTION
Hi,

First of all, thanks a lot for writing and maintaining cloup!

I am the maintainer of the Debian package of click; I uploaded click 8.2.0 to the Debian unstable suite a couple of days ago, and it turns out that might have been a bit premature, since there are a couple of incompatibilities that affect several other Python libraries.

What do you think about this change that conditionally passes the click context to `make_metavar()`?

Thanks in advance for your time, and keep up the great work!