### PR TITLE
fix for the click.__version__ deprecation warning

### DIFF
--- a/cloup/_util.py
+++ b/cloup/_util.py
@@ -1,4 +1,5 @@
 """Generic utilities."""
+import importlib.metadata
 from typing import (
     Any, Dict, Hashable, Iterable, List, Optional, Sequence, Type, TypeVar,
 )
@@ -7,7 +8,7 @@ import click
 
 from cloup.typing import MISSING, Possibly
 
-click_version_tuple = tuple(click.__version__.split('.'))
+click_version_tuple = tuple(importlib.metadata.version("click").split('.'))
 click_major = int(click_version_tuple[0])
 click_minor = int(click_version_tuple[1])
 click_version_ge_8_1 = (click_major, click_minor) >= (8, 1)

--- a/cloup/_util.py
+++ b/cloup/_util.py
@@ -4,8 +4,6 @@ from typing import (
     Any, Dict, Hashable, Iterable, List, Optional, Sequence, Type, TypeVar,
 )
 
-import click
-
 from cloup.typing import MISSING, Possibly
 
 click_version_tuple = tuple(importlib.metadata.version("click").split('.'))


### PR DESCRIPTION
Click will make `click.__version__` deprecated, here's the fix:

```
python -m cloup._util
<frozen runpy>:128: RuntimeWarning: 'cloup._util' found in sys.modules after import of package 'cloup', but prior to execution of 'cloup._util'; this may result in unpredictable behaviour
/Users/antonio/Projects/github/cloup/cloup/_util.py:10: DeprecationWarning: The '__version__' attribute is deprecated and will be removed in Click 9.1. Use feature detection or 'importlib.metadata.version("click")' instead.
```

after changes:
```
<frozen runpy>:128: RuntimeWarning: 'cloup._util' found in sys.modules after import of package 'cloup', but prior to execution of 'cloup._util'; this may result in unpredictable behaviour
```

## testing
```
tox -e dev
Python 3.9.6
  dev: OK (27.02=setup[27.01]+cmd[0.01] seconds)
  congratulations :) (27.17 seconds)
```