### PR TITLE
Avoid click deprecation warning about MultiGroup

### DIFF
--- a/cloup/_commands.py
+++ b/cloup/_commands.py
@@ -108,7 +108,7 @@ class Command(ConstraintMixin, OptionGroupMixin, click.Command):
         self.format_params(ctx, formatter)
         if self.must_show_constraints(ctx):
             self.format_constraints(ctx, formatter)  # type: ignore
-        if isinstance(self, click.MultiCommand):
+        if isinstance(self, click.Group):
             self.format_commands(ctx, formatter)
         self.format_epilog(ctx, formatter)
 


### PR DESCRIPTION
When using cloup I get:

```
  /Users/adam/Documents/repositories/doccmd/.venv/lib/python3.13/site-packages/cloup/_commands.py:111: DeprecationWarning: 'MultiCommand' is deprecated and will be removed in Click 9.0. Use 'Group' instead.
    if isinstance(self, click.MultiCommand):
```