### PR TITLE
Pin setuptools_scm<10 in setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def make_long_description(write_file=False):
 
 setup(
     name='cloup',
-    setup_requires=['setuptools_scm'],
+    setup_requires=['setuptools_scm<10'],
     use_scm_version={
         'write_to': 'cloup/_version.py'
     },


### PR DESCRIPTION
Got the following error in CI since `setuptools-scm` 10.0.0 was released:

```pythn
Run tox -e py312-click8
GLOB sdist-make: /home/runner/work/cloup/cloup/setup.py
ERROR: invocation failed (exit code 1), logfile: /home/runner/work/cloup/cloup/.tox/log/GLOB-0.log
================================== log start ===================================
/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/site-packages/setuptools/__init__.py:92: _DeprecatedInstaller: setuptools.installer and fetch_build_eggs are deprecated.
!!

        ********************************************************************************
        Requirements should be satisfied by a PEP 517 installer.
        If you are using pip, you can try `pip install --use-pep517`.

        This deprecation is overdue, please update your project and remove deprecated
        calls to avoid build errors in the future.
        ********************************************************************************

!!
  dist.fetch_build_eggs(dist.setup_requires)
Traceback (most recent call last):
  File "/home/runner/work/cloup/cloup/setup.py", line 17, in <module>
    setup(
  File "/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/site-packages/setuptools/__init__.py", line 117, in setup
    return distutils.core.setup(**attrs)  # type: ignore[return-value]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/site-packages/setuptools/_distutils/core.py", line 148, in setup
    _setup_distribution = dist = klass(attrs)
                                 ^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/site-packages/setuptools/dist.py", line 321, in __init__
    _Distribution.__init__(self, dist_attrs)
  File "/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/site-packages/setuptools/_distutils/dist.py", line 307, in __init__
    self.finalize_options()
  File "/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/site-packages/setuptools/dist.py", line 789, in finalize_options
    for ep in sorted(loaded, key=by_order):
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/site-packages/setuptools/dist.py", line 788, in <lambda>
    loaded = map(lambda e: e.load(), filtered)
                           ^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/importlib/metadata/__init__.py", line 205, in load
    module = import_module(match.group('module'))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1310, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1310, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 999, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/home/runner/work/cloup/cloup/.eggs/setuptools_scm-10.0.5-py3.12.egg/setuptools_scm/__init__.py", line 8, in <module>
    from vcs_versioning import Configuration
ModuleNotFoundError: No module named 'vcs_versioning'
```