### PR TITLE
Fix mypy errors from deprecated click.MultiCommand isinstance check

### DIFF
--- a/cloup/_commands.py
+++ b/cloup/_commands.py
@@ -108,7 +108,7 @@ class Command(ConstraintMixin, OptionGroupMixin, click.Command):
         self.format_params(ctx, formatter)
         if self.must_show_constraints(ctx):
             self.format_constraints(ctx, formatter)  # type: ignore
-        if isinstance(self, click.MultiCommand):
+        if isinstance(self, click.Group):
             self.format_commands(ctx, formatter)
         self.format_epilog(ctx, formatter)
 


### PR DESCRIPTION
Fixes #202.

`click.MultiCommand` is deprecated since Click 8 and is no longer usable as the second argument to `isinstance` at the type level, causing `mypy cloup` to fail on `master` with two errors in `cloup/_commands.py`. `click.Group` exposes `format_commands` on every supported Click version (`>= 8.0`), so the behavior at runtime is unchanged. This also silences the `DeprecationWarning` emitted when `format_help` is called on a group.

In practice, the only `MultiCommand` cloup ever produces is `cloup.Group` (which subclasses `click.Group`), so the original check was already effectively a Group check.

## Test plan

Tested across the full supported Click range (`>= 8.0, < 9.0`), Python 3.12, mypy 2.1.0:

| Click | pytest | mypy --strict cloup |
|---|---|---|
| 8.0.4 | 3 failures (pre-existing on master) | 2 errors (pre-existing on master) |
| 8.1.8 | 328 pass | clean |
| 8.2.1 | 328 pass | clean |
| 8.3.3 | 328 pass | clean |
| 8.4.1 | 328 pass | 1 error in `_params.pyi` (fixed by #201) |

The Click 8.0 issues reproduce on `master` without this change and are unrelated:
- pytest: `cloup/types.py` passes `executable=...` to `click.Path`, a kwarg added in a later Click 8.x
- mypy: two `# type: ignore` comments on `@overload` decorators (lines 273, 350) become unused because the underlying mypy warning doesn't fire against Click 8.0's older stubs

🤖 Generated with [Claude Code](https://claude.com/claude-code)