### PR TITLE
Unpin setuptools_scm upper bound in setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def make_long_description(write_file=False):
 
 setup(
     name='cloup',
-    setup_requires=['setuptools_scm<10'],
+    setup_requires=['setuptools_scm'],
     use_scm_version={
         'write_to': 'cloup/_version.py'
     },


### PR DESCRIPTION
# Unpin setuptools_scm upper bound in setup_requires

## Summary

`setup.py` pinned `setuptools_scm` to `<10`, which blocks installation whenever a
newer `setuptools_scm` (already released) is the only version available in the
environment. This PR removes the upper bound so any compatible `setuptools_scm`
release can satisfy the build requirement, as requested in the issue.

Fixes #206

## Changes

- `setup.py`: changed `setup_requires=['setuptools_scm<10']` to
  `setup_requires=['setuptools_scm']` (removes the `<10` pin).

No other version constraints on `setuptools_scm` exist in the repository
(`setup.cfg` and the `requirements/` files pin only `setuptools`, not
`setuptools_scm`; there is no `pyproject.toml`).

## Testing

The change is a single metadata dependency pin; it has no runtime/code effect.
I verified by repository-wide search (`grep -rn "setuptools_scm" --include=...`)
that this was the only place the version was pinned, so no other file needs
updating. The sandbox used to run build/test commands (`sandbox-run`) is
currently unable to start on this VM (`bwrap: setting up uid map: Permission
denied`, confirmed by `bin/sandbox-selftest`), so I could not run
`python setup.py sdist`/`bdist_wheel` against `setuptools-scm>=10` here. The
maintainer's earlier feedback in the issue notes that builds work with
`setuptools-scm>=10`; this PR simply removes the pin that prevented that.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
