### PR TITLE
fix(formatting): separate wrapped constraints from option lists

### DIFF
--- a/cloup/formatting/_formatter.py
+++ b/cloup/formatting/_formatter.py
@@ -229,6 +229,7 @@ class HelpFormatter(click.HelpFormatter):
                 self.write("\n")
                 with self.indentation():
                     self.write_text(constraint_text, theme.constraint)
+                self.write("\n")
 
         with self.indentation():
             if s.help:

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -225,6 +225,7 @@ def test_write_section_print_long_constraint_on_a_new_line():
         The heading:
             [This is a long constraint description that doesn't fit the line
             xx.]
+
             This is the help.
             term  This is the definition.
         """)


### PR DESCRIPTION
Fixes #182

## Problem

Long option-group constraint descriptions are rendered as a block directly
above the option definitions. Without spacing, the last wrapped line can
look like part of the option list.

## Change

Add one blank line between a block-rendered constraint and the following
section content. Constraints that fit inline beside the heading are unchanged.

## Tests

- Updated focused formatter coverage for wrapped constraint spacing.
- Full test suite: 328 passed, 44 warnings, 0 failed.

## Compatibility

No API changes. Output changes only for constraints rendered below the
section heading.

## AI assistance

AI-assisted tools were used for repository analysis and test drafting.
I reviewed the final diff, reproduced the issue locally, and ran the full
test suite.

Base: 7eba003b4fe2ed6c8c5492e5268ca6796103087a
