### PR TITLE
Fix drift wrt click>=8.2: in commands, support `deprecated` of type `str` to display `f"(DEPRECATED: {deprecated})"`

### DIFF
--- a/cloup/_commands.py
+++ b/cloup/_commands.py
@@ -292,7 +292,7 @@ class Group(SectionMixin, Command, click.Group):
         add_help_option: bool = True,
         no_args_is_help: bool = False,
         hidden: bool = False,
-        deprecated: bool = False,
+        deprecated: Union[bool, str] = False,
         align_option_groups: Optional[bool] = None,
         show_constraints: Optional[bool] = None,
         params: Optional[List[click.Parameter]] = None,
@@ -314,7 +314,7 @@ class Group(SectionMixin, Command, click.Group):
         add_help_option: bool = True,
         no_args_is_help: bool = False,
         hidden: bool = False,
-        deprecated: bool = False,
+        deprecated: Union[bool, str] = False,
         params: Optional[List[click.Parameter]] = None,
         **kwargs: Any,
     ) -> Callable[[AnyCallable], C]:
@@ -374,7 +374,7 @@ class Group(SectionMixin, Command, click.Group):
         add_help_option: bool = True,
         chain: bool = False,
         hidden: bool = False,
-        deprecated: bool = False,
+        deprecated: Union[bool, str] = False,
         show_subcommand_aliases: bool = False,
     ) -> Callable[[AnyCallable], click.Group]:
         ...
@@ -396,7 +396,7 @@ class Group(SectionMixin, Command, click.Group):
         add_help_option: bool = True,
         chain: bool = False,
         hidden: bool = False,
-        deprecated: bool = False,
+        deprecated: Union[bool, str] = False,
         params: Optional[List[click.Parameter]] = None,
         **kwargs: Any
     ) -> Callable[[AnyCallable], G]:
@@ -458,7 +458,7 @@ def command(
     add_help_option: bool = True,
     no_args_is_help: bool = False,
     hidden: bool = False,
-    deprecated: bool = False,
+    deprecated: Union[bool, str] = False,
     align_option_groups: Optional[bool] = None,
     show_constraints: Optional[bool] = None,
     params: Optional[List[click.Parameter]] = None,
@@ -480,7 +480,7 @@ def command(  # In this overload: "cls: ClickCommand"
     add_help_option: bool = True,
     no_args_is_help: bool = False,
     hidden: bool = False,
-    deprecated: bool = False,
+    deprecated: Union[bool, str] = False,
     params: Optional[List[click.Parameter]] = None,
     **kwargs: Any
 ) -> Callable[[AnyCallable], C]:
@@ -554,7 +554,8 @@ def command(
     :param hidden:
         hide this command from help outputs.
     :param deprecated:
-        issues a message indicating that the command is deprecated.
+        issues a message indicating that the command is deprecated. A string
+        provides a custom deprecation message (requires Click >= 8.2).
     :param align_option_groups:
         whether to align the columns of all option groups' help sections.
         This is also available as a context setting having a lower priority
@@ -620,7 +621,7 @@ def group(
     add_help_option: bool = True,
     chain: bool = False,
     hidden: bool = False,
-    deprecated: bool = False,
+    deprecated: Union[bool, str] = False,
     params: Optional[List[click.Parameter]] = None,
     show_subcommand_aliases: bool = False,
 ) -> Callable[[AnyCallable], Group]:
@@ -644,7 +645,7 @@ def group(
     add_help_option: bool = True,
     chain: bool = False,
     hidden: bool = False,
-    deprecated: bool = False,
+    deprecated: Union[bool, str] = False,
     params: Optional[List[click.Parameter]] = None,
     **kwargs: Any
 ) -> Callable[[AnyCallable], G]:
@@ -704,7 +705,8 @@ def group(
     :param hidden:
         hide this command from help outputs.
     :param deprecated:
-        issues a message indicating that the command is deprecated.
+        issues a message indicating that the command is deprecated. A string
+        provides a custom deprecation message (requires Click >= 8.2).
     :param invoke_without_command:
         this controls how the multi command itself is invoked. By default it's
         only invoked if a subcommand is provided.

--- a/cloup/_commands.py
+++ b/cloup/_commands.py
@@ -555,7 +555,7 @@ def command(
         hide this command from help outputs.
     :param deprecated:
         issues a message indicating that the command is deprecated. A string
-        provides a custom deprecation message (requires Click >= 8.2).
+        provides a custom deprecation message.
     :param align_option_groups:
         whether to align the columns of all option groups' help sections.
         This is also available as a context setting having a lower priority
@@ -706,7 +706,7 @@ def group(
         hide this command from help outputs.
     :param deprecated:
         issues a message indicating that the command is deprecated. A string
-        provides a custom deprecation message (requires Click >= 8.2).
+        provides a custom deprecation message.
     :param invoke_without_command:
         this controls how the multi command itself is invoked. By default it's
         only invoked if a subcommand is provided.

--- a/cloup/formatting/_formatter.py
+++ b/cloup/formatting/_formatter.py
@@ -8,7 +8,7 @@ from typing import (
     Tuple, Union,
 )
 
-from cloup._util import click_version_ge_8_1, click_version_ge_8_2
+from cloup._util import click_version_ge_8_1
 from cloup.formatting._util import unstyled_len
 
 if TYPE_CHECKING:
@@ -25,6 +25,13 @@ from ..typing import MISSING, Possibly
 from cloup.styling import HelpTheme, IStyle
 
 Definition = Tuple[str, Union[str, Callable[[int], str]]]
+
+
+def _format_deprecated_label(deprecated: Union[bool, str]) -> str:
+    """Return the parenthesized deprecation label shown in help text."""
+    if isinstance(deprecated, str):
+        return f"(DEPRECATED: {deprecated})"
+    return "(DEPRECATED)"
 
 
 @dc.dataclass()
@@ -185,14 +192,8 @@ class HelpFormatter(click.HelpFormatter):
         if help_text and click_version_ge_8_1:
             help_text = inspect.cleandoc(help_text).partition("\f")[0]
         if cmd.deprecated:
-            if click_version_ge_8_2:
-                label = (
-                    f"(DEPRECATED: {cmd.deprecated})"
-                    if isinstance(cmd.deprecated, str) else "(DEPRECATED)"
-                )
-                help_text = f"{help_text} {label}" if help_text else label
-            else:
-                help_text = "(Deprecated) " + help_text
+            label = _format_deprecated_label(cmd.deprecated)
+            help_text = f"{help_text} {label}" if help_text else label
         if help_text:
             self.write_paragraph()
             with self.indentation():

--- a/cloup/formatting/_formatter.py
+++ b/cloup/formatting/_formatter.py
@@ -27,7 +27,7 @@ from cloup.styling import HelpTheme, IStyle
 Definition = Tuple[str, Union[str, Callable[[int], str]]]
 
 
-def _format_deprecated_label(deprecated: Union[bool, str]) -> str:
+def _format_deprecation_label(deprecated: Union[bool, str]) -> str:
     """Return the parenthesized deprecation label shown in help text."""
     if isinstance(deprecated, str):
         return f"(DEPRECATED: {deprecated})"
@@ -192,8 +192,8 @@ class HelpFormatter(click.HelpFormatter):
         if help_text and click_version_ge_8_1:
             help_text = inspect.cleandoc(help_text).partition("\f")[0]
         if cmd.deprecated:
-            label = _format_deprecated_label(cmd.deprecated)
-            help_text = f"{help_text} {label}" if help_text else label
+            deprecation = _format_deprecation_label(cmd.deprecated)
+            help_text = f"{help_text} {deprecation}" if help_text else deprecation
         if help_text:
             self.write_paragraph()
             with self.indentation():

--- a/cloup/formatting/_formatter.py
+++ b/cloup/formatting/_formatter.py
@@ -8,7 +8,7 @@ from typing import (
     Tuple, Union,
 )
 
-from cloup._util import click_version_ge_8_1
+from cloup._util import click_version_ge_8_1, click_version_ge_8_2
 from cloup.formatting._util import unstyled_len
 
 if TYPE_CHECKING:
@@ -185,9 +185,14 @@ class HelpFormatter(click.HelpFormatter):
         if help_text and click_version_ge_8_1:
             help_text = inspect.cleandoc(help_text).partition("\f")[0]
         if cmd.deprecated:
-            # Use the same label as Click:
-            # https://github.com/pallets/click/blob/b0538df/src/click/core.py#L1331
-            help_text = "(Deprecated) " + help_text
+            if click_version_ge_8_2:
+                label = (
+                    f"(DEPRECATED: {cmd.deprecated})"
+                    if isinstance(cmd.deprecated, str) else "(DEPRECATED)"
+                )
+                help_text = f"{help_text} {label}" if help_text else label
+            else:
+                help_text = "(Deprecated) " + help_text
         if help_text:
             self.write_paragraph()
             with self.indentation():

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -4,7 +4,7 @@ import click
 import pytest
 
 import cloup
-from cloup._util import reindent
+from cloup._util import click_version_ge_8_2, reindent
 from tests.util import new_dummy_func
 
 
@@ -52,6 +52,46 @@ def test_group_works_with_no_params_and_subcommands(runner):
         Options:
           --help  Show this message and exit.
     """)
+
+
+@pytest.mark.parametrize('command_cls, reference_cls', [
+    (cloup.Command, click.Command),
+    (cloup.Group, click.Group),
+])
+@pytest.mark.parametrize('help_text', [
+    None, '', 'Do a thing.', 'First paragraph.\n\nSecond paragraph.\fHidden text.',
+])
+@pytest.mark.parametrize('deprecated', [False, True, '', 'use `newcmd` instead'])
+def test_deprecated_command_help_matches_click(
+    runner, command_cls, reference_cls, help_text, deprecated,
+):
+    cmd = command_cls(name='example', help=help_text, deprecated=deprecated)
+    reference = reference_cls(name='example', help=help_text, deprecated=deprecated)
+
+    result = runner.invoke(cmd, ['--help'], terminal_width=80)
+    expected = runner.invoke(reference, ['--help'], terminal_width=80)
+
+    assert result.exit_code == expected.exit_code == 0
+    # Older Click 8.2 releases add an extra space before a standalone label.
+    expected_output = expected.output.replace('\n   (DEPRECATED', '\n  (DEPRECATED')
+    assert result.output == expected_output
+
+
+@pytest.mark.skipif(not click_version_ge_8_2, reason='requires Click 8.2 or newer')
+def test_deprecated_command_help_keeps_theme(runner):
+    @cloup.command(
+        deprecated='use `newcmd` instead',
+        formatter_settings={'theme': cloup.HelpTheme(
+            command_help=cloup.Style(fg='yellow'),
+        )},
+    )
+    def example():
+        """Do a thing."""
+
+    result = runner.invoke(example, ['--help'], color=True)
+    assert result.exit_code == 0
+    assert click.style('Do a thing. (DEPRECATED: use `newcmd` instead)', fg='yellow') \
+        in result.output
 
 
 class TestDidYouMean:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -4,7 +4,7 @@ import click
 import pytest
 
 import cloup
-from cloup._util import click_version_ge_8_2, reindent
+from cloup._util import reindent
 from tests.util import new_dummy_func
 
 
@@ -54,32 +54,44 @@ def test_group_works_with_no_params_and_subcommands(runner):
     """)
 
 
-@pytest.mark.parametrize('command_cls, reference_cls', [
-    (cloup.Command, click.Command),
-    (cloup.Group, click.Group),
+@pytest.mark.parametrize('decorator, usage_args', [
+    (cloup.command, '[OPTIONS]'),
+    (cloup.group, '[OPTIONS] COMMAND [ARGS]...'),
 ])
-@pytest.mark.parametrize('help_text', [
-    None, '', 'Do a thing.', 'First paragraph.\n\nSecond paragraph.\fHidden text.',
+@pytest.mark.parametrize('help_text, expected_help', [
+    (None, ''),
+    ('', ''),
+    ('Do a thing.', 'Do a thing.'),
+    ('First paragraph.\n\nSecond paragraph.', 'First paragraph.\n\n  Second paragraph.'),
+    ('\n    Do a thing.\n    On another line.', 'Do a thing. On another line.'),
+    ('Visible text.\fHidden text.', 'Visible text.'),
 ])
-@pytest.mark.parametrize('deprecated', [False, True, '', 'use `newcmd` instead'])
-def test_deprecated_command_help_matches_click(
-    runner, command_cls, reference_cls, help_text, deprecated,
+@pytest.mark.parametrize('deprecated, expected_label', [
+    (False, ''),
+    (True, '(DEPRECATED)'),
+    ('', ''),
+    ('use `newcmd` instead', '(DEPRECATED: use `newcmd` instead)'),
+])
+def test_deprecated_command_help(
+    runner, decorator, usage_args, help_text, expected_help, deprecated, expected_label,
 ):
-    cmd = command_cls(name='example', help=help_text, deprecated=deprecated)
-    reference = reference_cls(name='example', help=help_text, deprecated=deprecated)
+    cmd = decorator(name='example', help=help_text, deprecated=deprecated)(
+        new_dummy_func())
 
     result = runner.invoke(cmd, ['--help'], terminal_width=80)
-    expected = runner.invoke(reference, ['--help'], terminal_width=80)
 
-    assert result.exit_code == expected.exit_code == 0
-    # Older Click 8.2 releases add an extra space before a standalone label.
-    expected_output = expected.output.replace('\n   (DEPRECATED', '\n  (DEPRECATED')
+    assert result.exit_code == 0
+    body = ' '.join(part for part in (expected_help, expected_label) if part)
+    expected_output = f'Usage: example {usage_args}\n'
+    if body:
+        expected_output += f'\n  {body}\n'
+    expected_output += '\nOptions:\n  --help  Show this message and exit.\n'
     assert result.output == expected_output
 
 
-@pytest.mark.skipif(not click_version_ge_8_2, reason='requires Click 8.2 or newer')
-def test_deprecated_command_help_keeps_theme(runner):
-    @cloup.command(
+@pytest.mark.parametrize('decorator', [cloup.command, cloup.group])
+def test_deprecated_command_help_keeps_theme(runner, decorator):
+    @decorator(
         deprecated='use `newcmd` instead',
         formatter_settings={'theme': cloup.HelpTheme(
             command_help=cloup.Style(fg='yellow'),


### PR DESCRIPTION
Fixes #211.

Deprecated command and group help appends `(DEPRECATED)` for boolean deprecation or `(DEPRECATED: reason)` for a custom string. A typed local `_format_deprecated_label` helper produces these labels, and their rendering no longer depends on the installed Click version. False and empty-string values leave the command undeprecated. Custom help styling, empty help, paragraph handling and form-feed truncation are preserved.

The command/group decorator overloads accept `Union[bool, str]`, and their documentation describes the custom-message contract without a version caveat. Tests exercise this Cloup contract through the public decorators rather than deriving expected output from whichever Click version is installed. The planned dependency-minimum update remains separate from this formatter change.

Validation on Windows:

- 50 focused command/group help and theme cases pass on Click 8.1.8, 8.2.1 and 8.5.0. Before removing the legacy branch, 26 of these cases failed with Click 8.1.8.
- Full suites: 378 passed on Python 3.9 / Click 8.1.8; 378 passed on Python 3.12 / Click 8.2.1; 378 passed on Python 3.12 / Click 8.5.0.
- The original public-command reproduction passes with Click 8.5.0.
- Repository tox environments `lint`, `mypy`, `py39-click8` and `docs` pass; `git diff --check` passes.
- An additional mypy 2.3.1 / Click 8.5.0 check reports the existing `HelpFormatter.write_dl` override mismatch also recorded on the untouched base. That unrelated signature is unchanged.

Python 3.10/3.11/3.13 and Linux/macOS have not been tested locally for this revision.

AI tools assisted with implementation and validation.
