### PR TITLE
Fix positional arguments section: click.Argument do not lose their `help` + deprecation labels

### DIFF
--- a/src/cloup/_option_groups.py
+++ b/src/cloup/_option_groups.py
@@ -19,8 +19,7 @@ from typing import (
 import click
 from click import Option, Parameter
 
-import cloup
-from cloup._params import option, make_arg_metavar
+from cloup._params import option
 from cloup._util import first_bool, make_repr
 from cloup.constraints import Constraint
 from cloup.formatting import HelpSection, ensure_is_cloup_formatter
@@ -200,9 +199,8 @@ class OptionGroupMixin:
     def get_argument_help_record(
         self, arg: click.Argument, ctx: click.Context
     ) -> Tuple[str, str]:
-        if isinstance(arg, cloup.Argument):
-            return arg.get_help_record(ctx)
-        return make_arg_metavar(arg, ctx), ""
+        """Like Argument.get_help_record, but it returns a tuple even if help is empty"""
+        return arg.make_metavar(ctx), getattr(arg, "help", "")
 
     def get_arguments_help_section(self, ctx: click.Context) -> Optional[HelpSection]:
         args_with_help = (arg for arg in self.arguments if getattr(arg, "help", None))

--- a/src/cloup/_params.py
+++ b/src/cloup/_params.py
@@ -1,20 +1,51 @@
+import inspect
+
 import click
+from click import Context
 from click.decorators import _param_memo
 
+from cloup._util import click_version_ge_8_5
+from cloup.formatting._formatter import _format_deprecation_label
 
-def make_arg_metavar(arg, ctx) -> str:
-    return arg.make_metavar(ctx)
+if click_version_ge_8_5:
+    Argument = click.Argument
+else:
+    # Backport Click 8.5.0 feature
 
+    class Argument(click.Argument):
+        """A :class:`click.Argument` with help text."""
 
-class Argument(click.Argument):
-    """A :class:`click.Argument` with help text."""
+        def __init__(self, *args, help=None, deprecated=False, **attrs):
+            super().__init__(*args, **attrs)
 
-    def __init__(self, *args, help=None, **attrs):
-        super().__init__(*args, **attrs)
-        self.help = help
+            if help:
+                help = inspect.cleandoc(help)
 
-    def get_help_record(self, ctx):
-        return make_arg_metavar(self, ctx), self.help or ""
+            if deprecated:
+                label = _format_deprecation_label(deprecated)
+                help = f"{help} {label}" if help else label
+
+            self.help = help
+            self.deprecated = deprecated
+
+        def make_metavar(self, ctx: Context) -> str:
+            if self.metavar is not None:
+                return self.metavar
+            var = self.type.get_metavar(param=self, ctx=ctx)
+            if not var:
+                var = self.name.upper()
+            # Types like ``Choice`` and ``DateTime`` already surround their metavar
+            # with square brackets to enumerate the allowed values. Reuse those
+            # outer brackets as the optional-argument indicator instead of wrapping
+            # the metavar in a second pair, which would produce ``[[a|b|c]]``.
+            already_bracketed = var.startswith("[") and var.endswith("]")
+            if self.deprecated:
+                var += "!"
+            if not self.required and not already_bracketed:
+                var = f"[{var}]"
+            if self.nargs != 1:
+                var += "..."
+            return var
 
 
 class Option(click.Option):

--- a/src/cloup/_params.pyi
+++ b/src/cloup/_params.pyi
@@ -44,11 +44,14 @@ ShellCompleteArg = Callable[
     Union[List[CompletionItem], List[str]],
 ]
 
-def make_arg_metavar(arg: click.Argument, ctx: click.Context) -> str: ...
-
 class Argument(click.Argument):
-    def __init__(self, *args: Any, help: Optional[str] = None, **attrs: Any): ...
-    def get_help_record(self, ctx: click.Context) -> Tuple[str, str]: ...
+    def __init__(
+        self,
+        *args: Any,
+        help: Optional[str] = None,
+        deprecated: bool | str = False,
+        **attrs: Any,
+    ): ...
 
 class Option(click.Option):
     def __init__(self, *args: Any, group: Optional[OptionGroup] = None, **attrs: Any): ...
@@ -57,6 +60,7 @@ def argument(
     *param_decls: str,
     cls: Optional[Type[Argument]] = None,
     help: Optional[str] = None,
+    deprecated: bool | str = False,
     type: Optional[ParamTypeLike] = None,
     required: Optional[bool] = None,
     default: Optional[ParamDefault] = None,
@@ -78,6 +82,7 @@ def option(
     default: Optional[ParamDefault] = None,
     required: Optional[bool] = None,
     help: Optional[str] = None,
+    deprecated: bool | str = False,
     # Processing
     callback: Optional[ParamCallback[click.Option]] = None,
     is_eager: bool = False,

--- a/src/cloup/_util.py
+++ b/src/cloup/_util.py
@@ -1,5 +1,6 @@
 """Generic utilities."""
 
+import importlib.metadata
 from typing import (
     Any,
     Dict,
@@ -14,9 +15,9 @@ from typing import (
 
 from cloup.typing import MISSING, Possibly
 
-# click_version_tuple = tuple(importlib.metadata.version("click").split("."))
-# click_major = int(click_version_tuple[0])
-# click_minor = int(click_version_tuple[1])
+click_version_tuple = tuple(importlib.metadata.version("click").split("."))
+click_semver = tuple(int(x) for x in click_version_tuple[:3])
+click_version_ge_8_5 = click_semver >= (8, 5)
 
 T = TypeVar("T")
 K = TypeVar("K", bound=Hashable)

--- a/tests/example_command.py
+++ b/tests/example_command.py
@@ -182,7 +182,6 @@ Other options:
 Made with love by Gianluca.
 """.strip()
 
-
 if __name__ == "__main__":
     make_example_command(align_option_groups=False, tabular_help=True)(
         ["--help"], prog_name="clouptest"

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -4,7 +4,7 @@ import click
 import pytest
 
 import cloup
-from cloup._util import reindent
+from cloup._util import reindent, click_semver
 from tests.util import new_dummy_func
 
 
@@ -35,23 +35,27 @@ def test_group_handling_of_unknown_argument():
 def test_command_works_with_no_parameters(runner):
     cmd = cloup.Command(name="cmd", callback=new_dummy_func())
     res = runner.invoke(cmd, "--help")
-    assert res.output == reindent("""
+    assert res.output == reindent(
+        """
         Usage: cmd [OPTIONS]
 
         Options:
           --help  Show this message and exit.
-    """)
+        """
+    )
 
 
 def test_group_works_with_no_params_and_subcommands(runner):
     cmd = cloup.Group(name="cmd")
     res = runner.invoke(cmd, "--help")
-    assert res.output == reindent("""
+    assert res.output == reindent(
+        """
         Usage: cmd [OPTIONS] COMMAND [ARGS]...
 
         Options:
           --help  Show this message and exit.
-    """)
+        """
+    )
 
 
 @pytest.mark.parametrize(
@@ -143,32 +147,38 @@ class TestDidYouMean:
 
     def test_with_no_matches(self, runner, cmd):
         res = runner.invoke(cmd, "asdfdsgdfgdf")
-        assert res.output == reindent("""
+        assert res.output == reindent(
+            """
             Usage: cmd [OPTIONS] COMMAND [ARGS]...
             Try 'cmd --help' for help.
 
             Error: No such command 'asdfdsgdfgdf'.
-        """)
+            """
+        )
 
     def test_with_one_match(self, runner, cmd):
         res = runner.invoke(cmd, "clearr")
-        assert res.output == reindent("""
+        assert res.output == reindent(
+            """
             Usage: cmd [OPTIONS] COMMAND [ARGS]...
             Try 'cmd --help' for help.
 
             Error: No such command 'clearr'. Did you mean 'clear'?
-        """)
+            """
+        )
 
     def test_with_multiple_matches(self, runner, cmd):
         res = runner.invoke(cmd, "inst")
-        assert res.output == reindent("""
+        assert res.output == reindent(
+            """
             Usage: cmd [OPTIONS] COMMAND [ARGS]...
             Try 'cmd --help' for help.
 
             Error: No such command 'inst'. Did you mean one of these?
                ins
                install
-        """)
+            """
+        )
 
 
 @pytest.mark.parametrize("decorator", [cloup.command, cloup.group])
@@ -218,12 +228,14 @@ def test_group_command_class_is_used_to_create_subcommands(runner):
     assert isinstance(subcommand, CustomCommand)
 
     res = runner.invoke(my_cli, ["subcommand", "--help"])
-    assert res.output == reindent("""
-        Usage: cli subcommand [OPTIONS]
+    assert res.output == reindent(
+        """
+                Usage: cli subcommand [OPTIONS]
 
-        Options:
-          -h, --help  Show this message and exit.
-    """)
+                Options:
+                  -h, --help  Show this message and exit.
+                """
+    )
 
 
 def test_group_class_is_used_to_create_subgroups(runner):
@@ -252,3 +264,50 @@ def test_group_class_is_used_to_create_subgroups(runner):
     assert isinstance(sub_group, CustomGroup)
     assert isinstance(other_group, OtherCustomGroup)
     assert isinstance(other_sub_group, cloup.Group)
+
+
+@pytest.mark.skipif(click_semver < (8, 5), reason="do not support arguments with help")
+def test_click_positional_arguments_with_help_are_supported(runner):
+    @cloup.command()
+    @click.argument("input_path", help="Input path")
+    def cmd(_):
+        """Case B: click.argument(help=...) in a cloup command."""
+
+    res = runner.invoke(cmd, ["--help"], prog_name="example")
+    assert res.output == reindent(
+        """
+        Usage: example [OPTIONS] INPUT_PATH
+
+          Case B: click.argument(help=...) in a cloup command.
+
+        Positional arguments:
+          INPUT_PATH  Input path
+
+        Options:
+          --help      Show this message and exit.
+        """
+    )
+
+
+def test_deprecation_label_is_correctly_applied_to_cloup_arguments(runner):
+    @cloup.command()
+    @cloup.argument(
+        "input_path", help="Input path", deprecated="use --path instead", required=False
+    )
+    def cmd(_):
+        """A command."""
+
+    res = runner.invoke(cmd, ["--help"], prog_name="example")
+    assert res.output == reindent(
+        """
+        Usage: example [OPTIONS] [INPUT_PATH!]
+
+          A command.
+
+        Positional arguments:
+          [INPUT_PATH!]  Input path (DEPRECATED: use --path instead)
+
+        Options:
+          --help         Show this message and exit.
+        """
+    )


### PR DESCRIPTION
Fixes #210.
- #210

Regarding [this comment](https://github.com/janluke/cloup/issues/210#issuecomment-5594062546):
> There's another difference between Click and Cloup. Both print a "Positional arguments" section if at least 1 argument has `help` but:
> 
> * Cloup includes _all_ arguments in the section, including those with no `help`
> 
> * Click only includes arguments with a `help`.
> 
> 
> I guess the reasoning was that the arguments are already listed in the usage anyway, but I think this is potentially misleading for users.



I decided to keep Cloup behavior.