### PR TITLE
Require Click 8.5 and partially delegate some features to its upstream implementations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,8 @@ name: CI
 
 on:
   push:
-    branches: [master]
-    tags: [v*]
+    branches: [ master ]
+    tags: [ v* ]
   pull_request:
   workflow_dispatch:
   schedule:
@@ -42,12 +42,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        click: ["latest"]
+        python: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        click: [ "latest" ]
         include:
-          - { python: "3.14", click: "8.2" }
-          - { python: "3.14", click: "8.3" }
-          - { python: "3.14", click: "8.4" }
+          - { python: "3.14", click: "8.5" }
 
     steps:
       - name: Set test env name
@@ -119,7 +117,7 @@ jobs:
 
   publish:
     name: Publish package to PyPI
-    needs: [checks, tests]
+    needs: [ checks, tests ]
     if: >
       startsWith(github.ref, 'refs/tags/v') &&
       github.repository == 'janluke/cloup'

--- a/hatch.toml
+++ b/hatch.toml
@@ -49,7 +49,7 @@ python = ["3.10", "3.11", "3.12", "3.13", "3.14"]
 # latest version of Python, to limit the number of test envs.
 [[envs.test.matrix]]
 python = ["3.14"]
-click = ["8.2", "8.3", "8.4"]
+click = ["8.5"]
 
 [envs.test.overrides]
 matrix.click.dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
   "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-  "click >= 8.2.0, < 9.0",
+  "click >= 8.5.0, < 9.0",
   'typing_extensions; python_version <= "3.10"',
 ]
 dynamic = [

--- a/src/cloup/__init__.py
+++ b/src/cloup/__init__.py
@@ -9,6 +9,7 @@ __version__ = _version.version
 __version_tuple__ = _version.version_tuple
 
 from click import (
+    Argument,
     # decorators
     confirmation_option,
     help_option,
@@ -43,7 +44,7 @@ from .formatting import (
     HelpSection,
 )
 from ._context import Context, get_current_context, pass_context
-from ._params import Argument, Option, argument, option
+from ._params import Option, argument, option
 from ._option_groups import (
     OptionGroup,
     OptionGroupMixin,

--- a/src/cloup/_commands.py
+++ b/src/cloup/_commands.py
@@ -249,19 +249,13 @@ class Group(SectionMixin, Command, click.Group):
         :param error: the original error coming from Click.
         :return: the original error or a new one.
         """
-        import difflib
-
-        matches = difflib.get_close_matches(bad_name, valid_names)
-        if not matches:
-            return error
-        elif len(matches) == 1:
-            extra_msg = f"Did you mean '{matches[0]}'?"
-        else:
-            matches_list = "\n".join("   " + match for match in matches)
-            extra_msg = "Did you mean one of these?\n" + matches_list
-
-        error_msg = str(error) + " " + extra_msg
-        return click.exceptions.UsageError(error_msg, error.ctx)
+        suggestion_error = click.NoSuchCommand(
+            bad_name,
+            message=str(error),
+            possibilities=valid_names,
+            ctx=error.ctx,
+        )
+        return suggestion_error if suggestion_error.possibilities else error
 
     def must_show_subcommand_aliases(self, ctx: click.Context) -> bool:
         return first_bool(

--- a/src/cloup/_params.py
+++ b/src/cloup/_params.py
@@ -1,51 +1,5 @@
-import inspect
-
 import click
-from click import Context
 from click.decorators import _param_memo
-
-from cloup._util import click_version_ge_8_5
-from cloup.formatting._formatter import _format_deprecation_label
-
-if click_version_ge_8_5:
-    Argument = click.Argument
-else:
-    # Backport Click 8.5.0 feature
-
-    class Argument(click.Argument):
-        """A :class:`click.Argument` with help text."""
-
-        def __init__(self, *args, help=None, deprecated=False, **attrs):
-            super().__init__(*args, **attrs)
-
-            if help:
-                help = inspect.cleandoc(help)
-
-            if deprecated:
-                label = _format_deprecation_label(deprecated)
-                help = f"{help} {label}" if help else label
-
-            self.help = help
-            self.deprecated = deprecated
-
-        def make_metavar(self, ctx: Context) -> str:
-            if self.metavar is not None:
-                return self.metavar
-            var = self.type.get_metavar(param=self, ctx=ctx)
-            if not var:
-                var = self.name.upper()
-            # Types like ``Choice`` and ``DateTime`` already surround their metavar
-            # with square brackets to enumerate the allowed values. Reuse those
-            # outer brackets as the optional-argument indicator instead of wrapping
-            # the metavar in a second pair, which would produce ``[[a|b|c]]``.
-            already_bracketed = var.startswith("[") and var.endswith("]")
-            if self.deprecated:
-                var += "!"
-            if not self.required and not already_bracketed:
-                var = f"[{var}]"
-            if self.nargs != 1:
-                var += "..."
-            return var
 
 
 class Option(click.Option):
@@ -61,10 +15,10 @@ GroupedOption = Option
 
 
 def argument(*param_decls, cls=None, **attrs):
-    ArgumentClass = cls or Argument
+    cls = cls or click.Argument
 
     def decorator(f):
-        _param_memo(f, ArgumentClass(param_decls, **attrs))
+        _param_memo(f, cls(param_decls, **attrs))
         return f
 
     return decorator

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -174,9 +174,32 @@ class TestDidYouMean:
             Usage: cmd [OPTIONS] COMMAND [ARGS]...
             Try 'cmd --help' for help.
 
-            Error: No such command 'inst'. Did you mean one of these?
-               ins
-               install
+            Error: No such command 'inst'. (Did you mean one of: 'ins', 'install'?)
+            """
+        )
+
+    def test_raises_click_no_such_command_with_alias_possibilities(self, cmd):
+        with pytest.raises(click.NoSuchCommand) as exc_info:
+            cmd.main(["inst"], prog_name="cmd", standalone_mode=False)
+
+        assert exc_info.value.possibilities == ["ins", "install"]
+
+    def test_token_normalization_preserves_fallback_behavior(self, runner):
+        cmd = cloup.Group(
+            name="cmd", context_settings={"token_normalize_func": str.lower}
+        )
+        cmd.add_command(
+            cloup.Command(name="install", aliases=["ins"], callback=new_dummy_func())
+        )
+
+        res = runner.invoke(cmd, "INSS")
+
+        assert res.output == reindent(
+            """
+            Usage: cmd [OPTIONS] COMMAND [ARGS]...
+            Try 'cmd --help' for help.
+
+            Error: No such command 'inss'.
             """
         )
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -4,7 +4,7 @@ import click
 import pytest
 
 import cloup
-from cloup._util import reindent, click_semver
+from cloup._util import reindent
 from tests.util import new_dummy_func
 
 
@@ -266,7 +266,6 @@ def test_group_class_is_used_to_create_subgroups(runner):
     assert isinstance(other_sub_group, cloup.Group)
 
 
-@pytest.mark.skipif(click_semver < (8, 5), reason="do not support arguments with help")
 def test_click_positional_arguments_with_help_are_supported(runner):
     @cloup.command()
     @click.argument("input_path", help="Input path")


### PR DESCRIPTION
## Summary

- require Click 8.5 and update the compatibility matrix
  - we still test explicitly for 8.5, even if it's currently the latest version as well; this means we'll have duplicated test envs until 8.6 is out; the pro is that I don't need to remember to modify the matrix when click 8.6 is out.

- remove the custom `cloup.Argument` implementation used only when click < 8.5
  - NOTE: the remaining part of the feature implementation remains  in Cloup; for click >= 8.5, we already defined `cloup.Argument` as an alias of `click.Argument`

- delegate "did you mean <cmd>?" suggestions feature to Click `NoSuchCommand`
  - keep Cloup aliases as suggestion candidates and preserve token-normalization fallback behavior

Closes #222.
Closes #199.