### PR TITLE
Make `HelpTheme` methods usable by subclasses

### DIFF
--- a/docs/pages/formatting.rst
+++ b/docs/pages/formatting.rst
@@ -154,6 +154,50 @@ the styles using :meth:`HelpTheme.with_`, e.g.:
     )
 
 
+Extending themes
+~~~~~~~~~~~~~~~~
+
+You can add fields by subclassing :class:`HelpTheme` with a frozen dataclass.
+The predefined theme methods create instances of your subclass, using the defaults
+for its additional fields. The :meth:`~HelpTheme.with_` method preserves the subclass
+and accepts its additional fields as keyword arguments::
+
+    from dataclasses import dataclass
+    from cloup import HelpTheme, Style
+    from cloup.styling import IStyle
+
+    @dataclass(frozen=True)
+    class MyTheme(HelpTheme):
+        metavar: IStyle = Style()
+
+    theme = MyTheme.dark().with_(metavar=Style(fg="cyan"))
+
+If a subclass needs its own predefined colors, it can reuse the base presets and
+then customize the added fields:
+
+.. code-block:: python
+
+    @dataclass(frozen=True)
+    class MyTheme(HelpTheme):
+        metavar: IStyle = Style()
+
+        @classmethod
+        def dark(cls) -> "MyTheme":
+            return super().dark().with_(metavar=Style(fg="cyan"))
+
+        @classmethod
+        def light(cls) -> "MyTheme":
+            return super().light().with_(metavar=Style(fg="blue"))
+
+    dark_theme = MyTheme.dark()
+    light_theme = MyTheme.light()
+
+Additional keyword arguments to ``with_()`` are passed to ``dataclasses.replace()``
+as supplied, including ``None``. Invalid field names raise ``TypeError``. Custom
+fields are available for use by your own formatter code; adding a field does not
+change the built-in formatter's output.
+
+
 .. _row-separators:
 
 Row separators

--- a/src/cloup/styling.py
+++ b/src/cloup/styling.py
@@ -5,10 +5,16 @@ of the ``--help`` output.
 
 import dataclasses
 import dataclasses as dc
+import sys
 from dataclasses import dataclass
 from typing import Callable, Optional, Union
 
 import click
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 from cloup._util import FrozenSpace, identity
 from cloup.typing import MISSING, Possibly
@@ -93,19 +99,27 @@ class HelpTheme:
         alias: Optional[IStyle] = None,
         alias_secondary: Possibly[Optional[IStyle]] = MISSING,
         epilog: Optional[IStyle] = None,
-    ) -> "HelpTheme":
-        kwargs = {key: val for key, val in locals().items() if val is not None}
+        **kwargs: object,
+    ) -> Self:
+        """Return a theme of the same type with the supplied fields replaced.
+
+        Additional keyword arguments are passed to :func:`dataclasses.replace`
+        to support fields added by subclasses.
+        """
+        replacements = {key: val for key, val in locals().items() if val is not None}
         if alias_secondary is MISSING:
-            del kwargs["alias_secondary"]
-        kwargs.pop("self")
-        if kwargs:
-            return dataclasses.replace(self, **kwargs)
+            del replacements["alias_secondary"]
+        replacements.pop("self")
+        replacements.pop("kwargs")
+        replacements.update(kwargs)
+        if replacements:
+            return dataclasses.replace(self, **replacements)
         return self
 
-    @staticmethod
-    def dark() -> "HelpTheme":
+    @classmethod
+    def dark(cls) -> Self:
         """A theme assuming a dark terminal background color."""
-        return HelpTheme(
+        return cls(
             invoked_command=Style(fg="bright_yellow"),
             heading=Style(fg="bright_white", bold=True),
             constraint=Style(fg="magenta"),
@@ -114,10 +128,10 @@ class HelpTheme:
             alias_secondary=Style(fg="white"),
         )
 
-    @staticmethod
-    def light() -> "HelpTheme":
+    @classmethod
+    def light(cls) -> Self:
         """A theme assuming a light terminal background color."""
-        return HelpTheme(
+        return cls(
             invoked_command=Style(fg="yellow"),
             heading=Style(fg="bright_blue"),
             constraint=Style(fg="red"),

--- a/tests/test_styling.py
+++ b/tests/test_styling.py
@@ -1,9 +1,30 @@
 import inspect
+from dataclasses import dataclass
+from typing import Callable, Optional
 
 import click
 import pytest
+from typing_extensions import assert_type
 
-from cloup.styling import Color, HelpTheme, Style
+from cloup._util import identity
+from cloup.styling import Color, HelpTheme, IStyle, Style
+
+
+@dataclass(frozen=True)
+class CustomTheme(HelpTheme):
+    metavar: IStyle = identity
+    label: Optional[str] = "default"
+
+
+@dataclass(frozen=True)
+class PresetTheme(CustomTheme):
+    @classmethod
+    def dark(cls) -> "PresetTheme":
+        return super().dark().with_(metavar=Style(fg="cyan"))
+
+    @classmethod
+    def light(cls) -> "PresetTheme":
+        return super().light().with_(metavar=Style(fg="blue"))
 
 
 def test_help_theme_copy_with():
@@ -16,7 +37,7 @@ def test_help_theme_copy_with():
 def test_help_theme_copy_with_takes_the_same_parameters_of_constructor():
     def get_param_names(func):
         params = inspect.signature(func).parameters
-        return list(params.keys())
+        return [name for name, param in params.items() if param.kind != param.VAR_KEYWORD]
 
     constructor_params = get_param_names(HelpTheme)
     method_params = get_param_names(HelpTheme.with_)[1:]  # skip self
@@ -26,6 +47,75 @@ def test_help_theme_copy_with_takes_the_same_parameters_of_constructor():
 def test_help_theme_default_themes():
     assert isinstance(HelpTheme.dark(), HelpTheme)
     assert isinstance(HelpTheme.light(), HelpTheme)
+
+
+@pytest.mark.parametrize("preset", ["dark", "light"])
+def test_help_theme_subclass_default_themes(preset: str) -> None:
+    theme = getattr(CustomTheme, preset)()
+    base_theme = getattr(HelpTheme, preset)()
+    assert type(theme) is CustomTheme
+    assert theme.metavar is identity
+    assert theme.label == "default"
+    for name in inspect.signature(HelpTheme).parameters:
+        assert getattr(theme, name) == getattr(base_theme, name)
+
+
+@pytest.mark.parametrize("factory", [CustomTheme, CustomTheme.dark, CustomTheme.light])
+def test_help_theme_subclass_copy_with(factory: Callable[[], CustomTheme]) -> None:
+    original = factory()
+    metavar, heading = Style(fg="cyan"), Style(bold=True)
+    theme = original.with_(metavar=metavar, heading=heading, label=None)
+
+    assert_type(theme, CustomTheme)
+    assert type(theme) is CustomTheme
+    assert theme.metavar is metavar
+    assert theme.heading is heading
+    assert theme.label is None
+    assert theme.col1 == original.col1
+    assert original.metavar is identity
+    assert original.label == "default"
+
+    updated = theme.with_(col2=Style(fg="red"))
+    assert type(updated) is CustomTheme
+    assert updated.metavar is metavar
+    assert updated.label is None
+    assert theme.with_() is theme
+    assert theme.with_(heading=None) is theme
+
+
+@pytest.mark.parametrize("factory", [HelpTheme, CustomTheme])
+def test_help_theme_copy_with_alias_secondary(factory: Callable[[], HelpTheme]) -> None:
+    style = Style(fg="cyan")
+    theme = factory().with_(alias_secondary=style)
+    assert theme.alias_secondary is style
+    assert theme.with_().alias_secondary is style
+    assert theme.with_(heading=style).alias_secondary is style
+    assert theme.with_(alias_secondary=None).alias_secondary is style
+
+
+@pytest.mark.parametrize("factory", [HelpTheme, CustomTheme])
+def test_help_theme_copy_with_rejects_unknown_fields(factory: Callable[[], HelpTheme]):
+    with pytest.raises(TypeError, match="unexpected keyword argument 'unknown'"):
+        factory().with_(unknown=Style())
+
+
+def test_help_theme_return_types() -> None:
+    assert_type(HelpTheme.dark(), HelpTheme)
+    assert_type(HelpTheme.light(), HelpTheme)
+    assert_type(HelpTheme().with_(), HelpTheme)
+    assert_type(CustomTheme.dark(), CustomTheme)
+    assert_type(CustomTheme.light(), CustomTheme)
+    assert_type(CustomTheme().with_(), CustomTheme)
+
+
+@pytest.mark.parametrize(("preset", "foreground"), [("dark", "cyan"), ("light", "blue")])
+def test_help_theme_subclass_can_customize_presets(preset: str, foreground: str) -> None:
+    theme = getattr(PresetTheme, preset)()
+
+    assert type(theme) is PresetTheme
+    assert theme.metavar == Style(fg=foreground)
+    assert theme.label == "default"
+    assert getattr(theme, "heading") == getattr(getattr(HelpTheme, preset)(), "heading")
 
 
 def test_style():


### PR DESCRIPTION
## Summary

Fix `HelpTheme` subclass support for issue #225.

- Make `dark()` and `light()` preserve subclasses and return `Self`.
- Allow `with_()` to update fields added by subclasses.
- Add regression coverage for subclass presets and custom fields.
- Document extending themes and reusing the base presets:

```python
from dataclasses import dataclass

from cloup import HelpTheme, Style
from cloup.styling import IStyle


@dataclass(frozen=True)
class MyTheme(HelpTheme):
    metavar: IStyle = Style()

    @classmethod
    def dark(cls) -> "MyTheme":
        return super().dark().with_(metavar=Style(fg="cyan"))

    @classmethod
    def light(cls) -> "MyTheme":
        return super().light().with_(metavar=Style(fg="blue"))


dark_theme = MyTheme.dark()
light_theme = MyTheme.light()
```

Closes #225.