### PR TITLE
Review type annotations for Click 8.5

### DIFF
--- a/src/cloup/_commands.py
+++ b/src/cloup/_commands.py
@@ -599,8 +599,8 @@ def command(
                     f"a `Command` must inherit from `cloup.ConstraintMixin` to support "
                     f"constraints; `{cls}` doesn't"
                 )
-            constraints = tuple(reversed(f.__cloup_constraints__))
-            del f.__cloup_constraints__
+            constraints = tuple(reversed(getattr(f, "__cloup_constraints__")))
+            delattr(f, "__cloup_constraints__")
             kwargs["constraints"] = constraints
 
         cmd_cls = cast(Type[Command], cls if cls is not None else Command)

--- a/src/cloup/_commands.py
+++ b/src/cloup/_commands.py
@@ -6,21 +6,18 @@ features, Cloup command decorators have detailed type hints and are generics so
 that type checkers can precisely infer the type of the returned command based on
 the ``cls`` argument.
 
-Why did you overload all decorators?
+Why do the decorators have overloads?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-I wanted that the return type of decorators depended from the ``cls`` argument
-but MyPy doesn't allow you to set a default value on a generic argument, see:
-https://github.com/python/mypy/issues/3737.
-So I had to resort to a workaround using @overload which makes things more
-verbose. '`@overload`` is on the ``cls`` argument:
+The overloads distinguish the default command class from an explicitly supplied
+``cls``, preserving the concrete return type for custom command classes. Click
+uses the same pattern. A generic parameter with a concrete default still does
+not work in MyPy; see https://github.com/python/mypy/issues/3737.
 
-- in one signature, ``cls`` has type ``None`` and it's set to ``None``; in this
-  case the type of the instantiated command is ``cloup.Command`` for ``@command``
-  and ``cloup.Group`` for ``@group``
-- in the other signature, there's ``cls: C`` without a default, where ``C`` is
-  a type variable; in this case the type of the instantiated command is ``C``.
+The explicit keyword parameters provide IDE completion and show defaults.
+``TypedDict`` and ``Unpack`` can describe shared keyword arguments, but do not
+record their default values. The custom-class overloads also allow arbitrary
+extra keywords for subclass constructors.
 
-When and if the MyPy issue is resolved, the overloads will be removed.
 """
 
 import inspect
@@ -126,13 +123,7 @@ class Command(ConstraintMixin, OptionGroupMixin, click.Command):
         self.format_params(ctx, formatter)
         if self.must_show_constraints(ctx):
             self.format_constraints(ctx, formatter)  # type: ignore
-        # We use hasattr() in place of isinstance(..., MultiCommand) because
-        # MultiCommand is not a valid type since Click 8.2, which merged MultiCommand
-        # with Group and deprecated it. Since then, MultiCommand returns a
-        # _MultiCommand(Group) fake class through a module-level __getattr__, and mypy
-        # complains that MultiCommand is not a type. This check can be eventually
-        # replaced by isinstance(self, click.Group) when we drop support for Click 8.1.
-        if hasattr(self, "format_commands"):
+        if isinstance(self, click.Group):
             self.format_commands(ctx, formatter)
         self.format_epilog(ctx, formatter)
 
@@ -289,10 +280,9 @@ class Group(SectionMixin, Command, click.Group):
                 + secondary_style(")")
             )
 
-    # MyPy complains because "Signature of "group" incompatible with supertype".
-    # The supertype signature is (*args, **kwargs), which is compatible with
-    # this provided that you pass all arguments (expect "name") as keyword arg.
-    @overload  # type: ignore
+    # Click also supports bare decorators and positional cls; Cloup requires
+    # parentheses and keyword-only cls, so this override is intentionally narrower.
+    @overload  # type: ignore[override]
     def command(  # Why overloading? Refer to module docstring.
         self,
         name: Optional[str] = None,
@@ -370,10 +360,8 @@ class Group(SectionMixin, Command, click.Group):
 
         return decorator
 
-    # MyPy complains: "signature of "group" incompatible with supertype".
-    # The supertype signature is (*args, **kwargs), which is compatible with
-    # this provided that you pass all arguments (expect "name") as keyword arg.
-    @overload  # type: ignore
+    # As with command(), Cloup intentionally has a narrower decorator API.
+    @overload  # type: ignore[override]
     def group(  # Why overloading? Refer to module docstring.
         self,
         name: Optional[str] = None,

--- a/src/cloup/_commands.py
+++ b/src/cloup/_commands.py
@@ -587,7 +587,8 @@ def command(
     """
     if callable(name):
         raise Exception(
-            f"you forgot parenthesis in the command decorator for `{name.__name__}`. "
+            f"you forgot parenthesis in the command decorator for "
+            f"`{getattr(name, '__name__', name)}`. "
             f"While parenthesis are optional in Click >= 8.1, they are required in Cloup."
         )
 

--- a/src/cloup/_commands.py
+++ b/src/cloup/_commands.py
@@ -374,7 +374,10 @@ class Group(SectionMixin, Command, click.Group):
         invoke_without_command: bool = False,
         no_args_is_help: bool = False,
         context_settings: Optional[Dict[str, Any]] = None,
-        formatter_settings: Dict[str, Any] = {},
+        formatter_settings: Optional[Dict[str, Any]] = None,
+        align_option_groups: Optional[bool] = None,
+        show_constraints: Optional[bool] = None,
+        params: Optional[List[click.Parameter]] = None,
         help: Optional[str] = None,
         epilog: Optional[str] = None,
         short_help: Optional[str] = None,
@@ -393,7 +396,7 @@ class Group(SectionMixin, Command, click.Group):
         name: Optional[str] = None,
         *,
         aliases: Optional[Iterable[str]] = None,
-        cls: Optional[Type[G]] = None,
+        cls: Type[G],
         section: Optional[Section] = None,
         invoke_without_command: bool = False,
         no_args_is_help: bool = False,
@@ -411,9 +414,9 @@ class Group(SectionMixin, Command, click.Group):
         **kwargs: Any,
     ) -> Callable[[AnyCallable], G]: ...
 
-    def group(  # type: ignore
+    def group(
         self,
-        name: Optional[None] = None,
+        name: Optional[str] = None,
         *,
         cls: Optional[Type[G]] = None,
         aliases: Optional[Iterable[str]] = None,
@@ -622,7 +625,9 @@ def group(
     invoke_without_command: bool = False,
     no_args_is_help: bool = False,
     context_settings: Optional[Dict[str, Any]] = None,
-    formatter_settings: Dict[str, Any] = {},
+    formatter_settings: Optional[Dict[str, Any]] = None,
+    align_option_groups: Optional[bool] = None,
+    show_constraints: Optional[bool] = None,
     help: Optional[str] = None,
     short_help: Optional[str] = None,
     epilog: Optional[str] = None,

--- a/src/cloup/_commands.py
+++ b/src/cloup/_commands.py
@@ -592,7 +592,7 @@ def command(
             f"While parenthesis are optional in Click >= 8.1, they are required in Cloup."
         )
 
-    def decorator(f: AnyCallable) -> C:
+    def decorator(f: AnyCallable) -> Union[Command, C]:
         if hasattr(f, "__cloup_constraints__"):
             if cls and not issubclass(cls, ConstraintMixin):
                 raise TypeError(
@@ -603,9 +603,9 @@ def command(
             delattr(f, "__cloup_constraints__")
             kwargs["constraints"] = constraints
 
-        cmd_cls = cast(Type[Command], cls if cls is not None else Command)
+        cmd_cls: Type[Union[Command, C]] = cls if cls is not None else Command
         try:
-            cmd = cast(C, click.command(name, cls=cmd_cls, **kwargs)(f))
+            cmd = click.command(name, cls=cmd_cls, **kwargs)(f)
             if aliases:
                 cmd.aliases = list(aliases)  # type: ignore
             return cmd
@@ -773,7 +773,7 @@ _ARGS_INFO = {
 
 
 def _process_unexpected_kwarg_error(
-    error: TypeError, args_info: Dict[str, _ArgInfo], cls: Type[Command]
+    error: TypeError, args_info: Dict[str, _ArgInfo], cls: Type[click.Command]
 ) -> TypeError:
     """Check if the developer tried to pass a Cloup-specific argument to a ``cls``
     that doesn't support it and if that's the case, augments the error message

--- a/src/cloup/_context.py
+++ b/src/cloup/_context.py
@@ -5,13 +5,15 @@ from functools import update_wrapper
 from typing import (
     Any,
     Callable,
+    Concatenate,
     cast,
     Dict,
     List,
+    Literal,
     Optional,
+    ParamSpec,
     Type,
     TypeVar,
-    TYPE_CHECKING,
     overload,
 )
 
@@ -22,20 +24,16 @@ from cloup._util import coalesce, pick_non_missing
 from cloup.formatting import HelpFormatter
 from cloup.typing import MISSING, Possibly
 
-if TYPE_CHECKING:
-    from typing_extensions import Concatenate, ParamSpec
-
-    P = ParamSpec("P")
-
+P = ParamSpec("P")
 R = TypeVar("R")
 
 
 @overload
-def get_current_context() -> "Context": ...
+def get_current_context(silent: Literal[False] = False) -> Context: ...
 
 
 @overload
-def get_current_context(silent: bool = False) -> "Optional[Context]": ...
+def get_current_context(silent: bool) -> Optional[Context]: ...
 
 
 def get_current_context(silent: bool = False) -> "Optional[Context]":
@@ -45,12 +43,12 @@ def get_current_context(silent: bool = False) -> "Optional[Context]":
     return cast(Optional[Context], click.get_current_context(silent=silent))
 
 
-def pass_context(f: "Callable[Concatenate[Context, P], R]") -> "Callable[P, R]":
+def pass_context(f: Callable[Concatenate[Context, P], R]) -> Callable[P, R]:
     """Marks a callback as wanting to receive the current context object as first
     argument. Equivalent to :func:`click.pass_context` but assumes the current context
     is of type :class:`cloup.Context`."""
 
-    def new_func(*args: "P.args", **kwargs: "P.kwargs") -> R:
+    def new_func(*args: P.args, **kwargs: P.kwargs) -> R:
         return f(get_current_context(), *args, **kwargs)
 
     return update_wrapper(new_func, f)

--- a/src/cloup/_option_groups.py
+++ b/src/cloup/_option_groups.py
@@ -391,7 +391,7 @@ def _option_group(
                         f'"{existing_group}" and then passed as argument to '
                         f"`@option_group({title!r}, ...)`"
                     )
-                new_option.group = opt_group  # type: ignore
+                new_option.group = opt_group  # type: ignore[attr-defined]
                 if hidden:
                     new_option.hidden = True
         return f

--- a/src/cloup/_params.py
+++ b/src/cloup/_params.py
@@ -1,9 +1,18 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
 import click
 from click.decorators import _param_memo
+
+if TYPE_CHECKING:
+    from ._option_groups import OptionGroup
 
 
 class Option(click.Option):
     """A :class:`click.Option` with an extra field ``group`` of type ``OptionGroup``."""
+
+    group: Optional[OptionGroup]
 
     def __init__(self, *args, group=None, **attrs):
         super().__init__(*args, **attrs)
@@ -29,13 +38,8 @@ def option(*param_decls, cls=None, group=None, **attrs):
     Refer to :class:`click.Option` and :class:`click.Parameter` for more info
     about the accepted parameters.
 
-    In your IDE, you won't see arguments relating to shell completion,
-    because they are different in Click 7 and 8 (both supported by Cloup):
-
-    - in Click 7, it's ``autocompletion``
-    - in Click 8, it's ``shell_complete``.
-
-    These arguments have different semantics, refer to Click's docs.
+    The type hints include Click's ``shell_complete`` callback and the
+    Cloup-specific ``group`` argument.
     """
     OptionClass = cls or Option
 

--- a/src/cloup/_params.pyi
+++ b/src/cloup/_params.pyi
@@ -7,7 +7,6 @@ from typing import (
     Callable,
     List,
     Optional,
-    Protocol,
     Sequence,
     Tuple,
     Type,
@@ -23,19 +22,7 @@ from cloup import OptionGroup
 F = TypeVar("F", bound=Callable[..., Any])
 P = TypeVar("P", bound=click.Parameter)
 
-class _ParamType(Protocol):
-    # Once Click 8.3 support is dropped, this can be replaced with
-    # click.ParamType[Any].
-    @property
-    def name(self) -> Optional[str]: ...
-    def convert(
-        self,
-        value: Any,
-        param: Optional[click.Parameter],
-        ctx: Optional[click.Context],
-    ) -> Any: ...
-
-SimpleParamTypeLike = Union[_ParamType, Type[float], Type[int], Type[str]]
+SimpleParamTypeLike = Union[click.ParamType[Any], Callable[[str], Any]]
 ParamTypeLike = Union[SimpleParamTypeLike, Tuple[SimpleParamTypeLike, ...]]
 ParamDefault = Union[Any, Callable[[], Any]]
 ParamCallback = Callable[[click.Context, P, Any], Any]
@@ -44,21 +31,14 @@ ShellCompleteArg = Callable[
     Union[List[CompletionItem], List[str]],
 ]
 
-class Argument(click.Argument):
-    def __init__(
-        self,
-        *args: Any,
-        help: Optional[str] = None,
-        deprecated: bool | str = False,
-        **attrs: Any,
-    ): ...
-
 class Option(click.Option):
+    group: Optional[OptionGroup]
+
     def __init__(self, *args: Any, group: Optional[OptionGroup] = None, **attrs: Any): ...
 
 def argument(
     *param_decls: str,
-    cls: Optional[Type[Argument]] = None,
+    cls: Optional[Type[click.Argument]] = None,
     help: Optional[str] = None,
     deprecated: bool | str = False,
     type: Optional[ParamTypeLike] = None,
@@ -88,7 +68,7 @@ def option(
     is_eager: bool = False,
     # Help text tuning
     show_choices: bool = True,
-    show_default: bool = False,
+    show_default: Union[bool, str, None] = None,
     show_envvar: bool = False,
     # Flag options
     flag_value: Optional[Any] = None,

--- a/src/cloup/_sections.py
+++ b/src/cloup/_sections.py
@@ -18,7 +18,7 @@ from cloup._util import first_bool, pick_not_none
 from cloup.formatting import HelpSection, ensure_is_cloup_formatter
 
 CommandType = TypeVar("CommandType", bound=Type[click.Command])
-Subcommands = Union[Iterable[click.Command], Dict[str, click.Command]]
+Subcommands = Union[Sequence[click.Command], Dict[str, click.Command]]
 
 
 class Section:
@@ -53,7 +53,7 @@ class Section:
             for cmd in commands:
                 self.add_command(cmd)
         elif isinstance(commands, dict):
-            self.commands = OrderedDict(commands)
+            self.commands = OrderedDict(commands.items())
         else:
             raise TypeError(
                 "argument `commands` must be a sequence of commands "

--- a/src/cloup/constraints/_support.py
+++ b/src/cloup/constraints/_support.py
@@ -28,7 +28,7 @@ class BoundConstraintSpec(NamedTuple):
     it has to check."""
 
     constraint: Constraint
-    param_names: Union[Sequence[str]]
+    param_names: Sequence[str]
 
     def resolve_params(self, cmd: "ConstraintMixin") -> "BoundConstraint":
         return BoundConstraint(self.constraint, cmd.get_params_by_name(self.param_names))

--- a/src/cloup/formatting/_formatter.py
+++ b/src/cloup/formatting/_formatter.py
@@ -185,8 +185,8 @@ class HelpFormatter(click.HelpFormatter):
     def available_width(self) -> int:
         return self.width - self.current_indent
 
-    def write(self, *strings: str) -> None:
-        self.buffer += strings
+    def write(self, string: str = "", *strings: str) -> None:
+        self.buffer += (string, *strings)
 
     def write_usage(
         self, prog: str, args: str = "", prefix: Optional[str] = None

--- a/src/cloup/formatting/sep.py
+++ b/src/cloup/formatting/sep.py
@@ -64,6 +64,7 @@ class RowSepCondition(Protocol):
     ) -> bool:
         """Return ``True`` if the input definition list should use a row
         separator (in addition to the usual ``\\n``)."""
+        ...
 
 
 class RowSepIf(RowSepPolicy):

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,0 +1,170 @@
+"""Public typing contracts, checked by MyPy and executable with pytest."""
+
+# mypy: warn-unused-ignores
+
+from typing import TYPE_CHECKING, Any, Optional, get_type_hints
+
+import click
+import pytest
+from click.testing import CliRunner
+from typing_extensions import assert_type
+
+import cloup
+
+
+class CustomCommand(cloup.Command):
+    def __init__(self, *, custom: bool = False, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.custom = custom
+
+
+class CustomGroup(cloup.Group):
+    def __init__(self, *, custom: bool = False, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.custom = custom
+
+
+def callback() -> None:
+    pass
+
+
+def test_command_decorator_types() -> None:
+    assert_type(cloup.command()(callback), cloup.Command)
+    assert_type(cloup.command(cls=None)(callback), cloup.Command)
+    cmd = cloup.command(cls=CustomCommand, custom=True)(callback)
+    assert_type(cmd, CustomCommand)
+    assert cmd.custom
+    assert_type(cloup.command(cls=click.Command)(callback), click.Command)
+
+    assert_type(cloup.group()(callback), cloup.Group)
+    assert_type(cloup.group(cls=None)(callback), cloup.Group)
+    grp = cloup.group(cls=CustomGroup, custom=True)(callback)
+    assert_type(grp, CustomGroup)
+    assert grp.custom
+    assert_type(cloup.group(cls=click.Group)(callback), click.Group)
+
+
+def test_subcommand_decorator_types() -> None:
+    parent = cloup.Group("parent")
+    # Defaults can be customized through command_class and group_class, so
+    # the inferred types must allow arbitrary Click commands and groups.
+    cmd = parent.command("default")(callback)
+    assert_type(cmd, click.Command)
+    assert isinstance(cmd, cloup.Command)
+    custom_cmd = parent.command("custom", cls=CustomCommand, custom=True)(callback)
+    assert_type(custom_cmd, CustomCommand)
+    assert custom_cmd.custom
+    grp = parent.group("default-group", cls=None)(callback)
+    assert_type(grp, click.Group)
+    assert isinstance(grp, cloup.Group)
+    custom_grp = parent.group("custom-group", cls=CustomGroup, custom=True)(callback)
+    assert_type(custom_grp, CustomGroup)
+    assert custom_grp.custom
+
+
+def test_group_inherited_keyword_types() -> None:
+    grp = cloup.group(
+        formatter_settings=None,
+        align_option_groups=True,
+        show_constraints=True,
+        params=[cloup.Option(["--value"])],
+    )(callback)
+    assert_type(grp, cloup.Group)
+    child = grp.group(
+        "child",
+        formatter_settings=None,
+        align_option_groups=True,
+        show_constraints=True,
+        params=[cloup.Option(["--other"])],
+    )(callback)
+    assert_type(child, click.Group)
+    assert child.params[0].name == "other"
+
+
+def test_parameter_decorators_preserve_callback_types() -> None:
+    def convert(value: str) -> int:
+        return int(value, 16)
+
+    def typed_callback(value: int) -> str:
+        return str(value)
+
+    option_callback = cloup.option("--value", type=convert)(typed_callback)
+    argument_callback = cloup.argument("value", cls=click.Argument)(typed_callback)
+    # Comparing calls also checks that argument and return types survive decorating.
+    assert_type(option_callback(1), str)
+    assert_type(argument_callback(value=2), str)
+    assert option_callback(1) == "1"
+    assert argument_callback(2) == "2"
+
+    @cloup.command()
+    @cloup.option("--value", type=(convert, cloup.INT), show_default="hex and int")
+    @cloup.argument("label", cls=cloup.Argument, type=str)
+    def cmd(value: tuple[int, int], label: str) -> None:
+        click.echo(f"{label}: {value}")
+
+    result = CliRunner().invoke(cmd, ["--value", "ff", "2", "pair"])
+    assert result.exit_code == 0
+    assert result.output == "pair: (255, 2)\n"
+    assert "hex and int" in CliRunner().invoke(cmd, ["--help"]).output
+
+    cloup.option("--enabled", type=bool, show_default=None)
+    cloup.option("--choice", type=cloup.Choice([1, 2]))
+
+
+def test_option_group_attribute_type() -> None:
+    group = cloup.OptionGroup("Options")
+    option = cloup.Option(["--value"], group=group)
+    assert_type(option.group, Optional[cloup.OptionGroup])
+    assert option.group is group
+
+
+def test_formatter_write_accepts_click_keyword() -> None:
+    formatter = cloup.HelpFormatter()
+    click_formatter: click.HelpFormatter = formatter
+    click_formatter.write(string="first")
+    formatter.write(" second", " third")
+    formatter.write()
+    assert formatter.getvalue() == "first second third"
+
+
+def test_context_types() -> None:
+    ctx = cloup.Context(cloup.Command("cmd"))
+    with ctx:
+        assert_type(cloup.get_current_context(), cloup.Context)
+        assert_type(cloup.get_current_context(False), cloup.Context)
+        assert_type(cloup.get_current_context(silent=False), cloup.Context)
+        assert_type(cloup.get_current_context(True), Optional[cloup.Context])
+        assert cloup.get_current_context(False) is ctx
+    assert cloup.get_current_context(silent=True) is None
+    with pytest.raises(RuntimeError):
+        cloup.get_current_context(False)
+
+
+def test_pass_context_preserves_signature() -> None:
+    @cloup.pass_context
+    def func(ctx: cloup.Context, value: int, *, suffix: str) -> str:
+        return f"{ctx.command.name}: {value}{suffix}"
+
+    with cloup.Context(cloup.Command("cmd")):
+        assert_type(func(1, suffix="!"), str)
+        assert func(1, suffix="!") == "cmd: 1!"
+
+    # ParamSpec and Concatenate are available at runtime on Python 3.10+.
+    assert get_type_hints(cloup.pass_context)["return"] is not None
+
+
+if TYPE_CHECKING:
+
+    def check_rejected_calls(silent: bool) -> None:
+        assert_type(cloup.get_current_context(silent), Optional[cloup.Context])
+        parent = cloup.Group("parent")
+        parent.group(unknown=True)  # type: ignore[call-overload]
+        parent.group(cls=None, unknown=True)  # type: ignore[call-overload]
+        cloup.option("--value", show_default=123)  # type: ignore[arg-type]
+
+        @cloup.pass_context
+        def func(ctx: cloup.Context, value: int) -> str:
+            return str(value)
+
+        func("wrong")  # type: ignore[arg-type]
+        func()  # type: ignore[call-arg]


### PR DESCRIPTION
Cloup's annotations still carried compatibility scaffolding from older Python and Click releases, and some public decorator signatures had drifted from the arguments accepted at runtime. This made valid calls harder to discover and weakened inference for context helpers and custom command classes.

This change:

- uses the Python 3.10 and Click 8.5 typing APIs directly;
- completes the command, group, context, formatter, section, and parameter contracts;
- keeps intentional dynamic attributes explicit and documents Cloup's narrower decorator API;
- removes broad casts and obsolete compatibility types; and
- adds executable typing contract coverage for public APIs and custom subclasses.

Validation:

- Ruff format and lint checks
- strict mypy checks for the package, tests, and examples
- 404 tests passed on the rebased branch
- Sphinx documentation build with warnings treated as errors
- the full supported Python and Click matrix (`task qa:all`) before the unrelated base-branch update
- package build and Twine checks

Closes #227
