### PR TITLE
Run Pyrefly alongside Mypy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,11 @@ jobs:
       - name: Install Hatch
         run: python -m pip install --upgrade hatch
 
-      - name: Check types
-        run: hatch run $TEST_ENV:typing
+      - name: Check types with Pyrefly
+        run: hatch run $TEST_ENV:typing-pyrefly
+
+      - name: Check types with mypy
+        run: hatch run $TEST_ENV:typing-mypy
 
       - name: Run tests with coverage
         run: hatch run $TEST_ENV:test-cov

--- a/hatch.toml
+++ b/hatch.toml
@@ -10,6 +10,7 @@ installer = "uv"
 dependencies = [
   "coverage[toml] >= 6.5",
   "mypy",
+  "pyrefly",
   "pytest",
   "pytest-cov",
   "pytest-xdist[psutil]",
@@ -28,10 +29,17 @@ test-cov = [
   "click-version",
   "coverage run --parallel-mode -m pytest {args:-vv}",
 ]
-typing = [
-  "click-version",
+typing-mypy = [
   "mypy --strict src/cloup",
   "mypy tests examples",
+]
+typing-pyrefly = [
+  "pyrefly check",
+]
+typing = [
+  "click-version",
+  "typing-pyrefly",
+  "typing-mypy",
 ]
 upgrade-click = '"$HATCH_UV" pip install --upgrade-package click -r pyproject.toml'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,13 @@ packages = ["src/cloup"]
 [tool.mypy]
 ignore_missing_imports = true
 
+[tool.pyrefly]
+preset = "default"
+project-includes = ["src/cloup", "tests/test_typing.py"]
+
+[tool.pyrefly.errors]
+unused-ignore = "error"
+
 [tool.ruff]
 extend-exclude = ["docs", "src/cloup/_version.py"]
 include = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,10 +62,17 @@ ignore_missing_imports = true
 
 [tool.pyrefly]
 preset = "default"
-project-includes = ["src/cloup", "tests/test_typing.py"]
+project-includes = ["src/cloup", "tests", "examples"]
+search-path = ["src", ".", "examples/manim"]
+ignore-missing-imports = ["click_default_group"]
 
 [tool.pyrefly.errors]
 unused-ignore = "error"
+
+[[tool.pyrefly.sub-config]]
+matches = "tests/**"
+# Match Mypy's default behavior for dynamic test helpers; annotated tests remain checked.
+check-unannotated-defs = false
 
 [tool.ruff]
 extend-exclude = ["docs", "src/cloup/_version.py"]

--- a/src/cloup/_commands.py
+++ b/src/cloup/_commands.py
@@ -285,6 +285,7 @@ class Group(SectionMixin, Command, click.Group):
     # Click also supports bare decorators and positional cls; Cloup requires
     # parentheses and keyword-only cls, so this override is intentionally narrower.
     @overload  # type: ignore[override]
+    # pyrefly: ignore[bad-override]
     def command(  # Why overloading? Refer to module docstring.
         self,
         name: Optional[str] = None,
@@ -364,6 +365,7 @@ class Group(SectionMixin, Command, click.Group):
 
     # As with command(), Cloup intentionally has a narrower decorator API.
     @overload  # type: ignore[override]
+    # pyrefly: ignore[bad-override]
     def group(  # Why overloading? Refer to module docstring.
         self,
         name: Optional[str] = None,

--- a/src/cloup/_commands.py
+++ b/src/cloup/_commands.py
@@ -74,6 +74,8 @@ class Command(ConstraintMixin, OptionGroupMixin, click.Command):
     .. versionadded:: 0.8.0
     """
 
+    # The Cloup command contract requires the Cloup context extensions.
+    # pyrefly: ignore[bad-override-mutable-attribute]
     context_class: Type[Context] = Context
 
     def __init__(

--- a/src/cloup/_context.py
+++ b/src/cloup/_context.py
@@ -114,6 +114,8 @@ class Context(click.Context):
         keyword arguments forwarded to :class:`click.Context`.
     """
 
+    # The Cloup context contract requires the Cloup formatter extensions.
+    # pyrefly: ignore[bad-override-mutable-attribute]
     formatter_class: Type[HelpFormatter] = HelpFormatter
 
     def __init__(

--- a/src/cloup/_option_groups.py
+++ b/src/cloup/_option_groups.py
@@ -69,10 +69,8 @@ class OptionGroup:
         if self.hidden:
             return []
         return [
-            opt.get_help_record(ctx)  # type: ignore[misc]
-            for opt in self
-            if not opt.hidden
-        ]  # get_help_record() should return None only if opt.hidden
+            record for opt in self if (record := opt.get_help_record(ctx)) is not None
+        ]
 
     def option(self, *param_decls: str, **attrs: Any) -> Callable[[F], F]:
         """Refer to :func:`cloup.option`."""

--- a/src/cloup/constraints/_core.py
+++ b/src/cloup/constraints/_core.py
@@ -167,6 +167,8 @@ class Constraint(abc.ABC):
             param_names = cast(Sequence[str], params)
             params_objects = ctx.command.get_params_by_name(param_names)
         else:
+            # Mypy does not narrow this union from the first element check.
+            # pyrefly: ignore[redundant-cast]
             params_objects = cast(Sequence[click.Parameter], params)
 
         if Constraint.must_check_consistency(ctx):

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -27,10 +27,12 @@ tasks:
 
   hatch-run:
     internal: true
+    requires:
+      vars: [ENVIRONMENT, SCRIPT]
     label: "{{.ENVIRONMENT}}:{{.SCRIPT}}"
     prefix: "{{.ENVIRONMENT}}:{{.SCRIPT}}"
     cmds:
-      - hatch run '{{.ENVIRONMENT}}:{{.SCRIPT}}' {{.ARGS}}
+      - hatch run {{.ENVIRONMENT}}:{{.SCRIPT}} {{.ARGS}}
 
   # Prepare shared environments before running scripts from them concurrently.
   # `hatch run` creates missing environments and also syncs existing ones.
@@ -83,19 +85,50 @@ tasks:
   # Static type checking
   #
 
-  typing:
-    desc: Type-check in the development environment.
+  mypy:
+    desc: Type-check with mypy in the development environment.
     cmds:
-      - hatch run dev:typing
+      - "hatch run dev:typing-mypy"
 
-  typing:all:
-    desc: Type-check every test environment in parallel.
+  pyrefly:
+    desc: Type-check with Pyrefly in the development environment.
+    cmds:
+      - "hatch run dev:typing-pyrefly"
+
+  typing:
+    desc: Type-check with Pyrefly, then mypy.
+    cmds:
+      - task: pyrefly
+      - task: mypy
+
+  mypy:all:
+    desc: Type-check with mypy every test environment in parallel.
     deps:
-      - for: {var: TEST_ENVS}
+      - for: { var: TEST_ENVS }
         task: hatch-run
         vars:
           ENVIRONMENT: "{{.ITEM}}"
-          SCRIPT: typing
+          SCRIPT: "typing-mypy"
+
+  pyrefly:all:
+    desc: Type-check with Pyrefly every test environment in parallel.
+    deps:
+      - for: { var: TEST_ENVS }
+        task: hatch-run
+        vars:
+          ENVIRONMENT: "{{.ITEM}}"
+          SCRIPT: "typing-pyrefly"
+
+  typing:all:
+    desc: Type-check every test environment in parallel.
+    cmds:
+      - task: prepare-envs
+        vars:
+          ENVS: "{{.TEST_ENVS}}"
+      - task: run-concurrently
+        vars:
+          TASKS: ["pyrefly:all", "mypy:all"]
+
 
   #
   # Testing

--- a/tests/constraints/conftest.py
+++ b/tests/constraints/conftest.py
@@ -1,4 +1,3 @@
-from typing import cast
 from unittest.mock import Mock
 
 import click
@@ -45,4 +44,4 @@ def sample_cmd() -> Command:
     def f(**kwargs):
         print("It works")
 
-    return cast(Command, f)
+    return f

--- a/tests/example_command.py
+++ b/tests/example_command.py
@@ -1,5 +1,3 @@
-from typing import cast
-
 import click
 
 import cloup
@@ -65,7 +63,7 @@ def make_example_command(
         expected_help = _LINEAR_HELP
 
     cmd.expected_help = expected_help  # type: ignore
-    return cast(Command, cmd)
+    return cmd
 
 
 _TABULAR_ALIGNED_HELP = """

--- a/tests/test_option_groups.py
+++ b/tests/test_option_groups.py
@@ -169,6 +169,18 @@ def test_that_optgroup_is_hidden_if_all_its_options_are_hidden(runner):
     assert "Hidden group" not in result.output
 
 
+def test_option_group_omits_options_without_help_records():
+    class OptionWithoutHelpRecord(click.Option):
+        def get_help_record(self, ctx: click.Context) -> None:
+            return None
+
+    group = OptionGroup("Options")
+    group.options = [OptionWithoutHelpRecord(["--empty"]), click.Option(["--shown"])]
+
+    ctx = click.Context(click.Command("cmd"))
+    assert group.get_help_records(ctx) == [("--shown TEXT", "")]
+
+
 def test_option_group_options_setter_set_the_hidden_attr_of_options():
     opts = make_options("abc")
     group = OptionGroup("name")


### PR DESCRIPTION
Add Pyrefly to the Hatch typing workflow and every CI test environment, using its default preset across package sources, tests, and examples. Hatch, CI, and the plain Task typing workflow run Pyrefly before Mypy for fast failure; the full Task matrix runs both checkers concurrently for throughput. Unannotated test helper bodies retain Mypy's existing treatment, while annotated tests remain fully checked.

The integration also makes option-group help collection defer to Click's `Option.get_help_record()` contract, including custom options that omit a help row, and records the intentional checker differences around Cloup's fixed class factories, narrower group decorator API, and sequence narrowing. The individual commit messages explain the motivation and tradeoffs for each change in detail.

Closes #233.
