### PR TITLE
Enable pyupgrade Ruff rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ target-version = "py310"
 [tool.ruff.lint]
 # Preserve Flake8's non-formatting error coverage while leaving formatter-owned
 # whitespace and line-length rules to `ruff format`. W503 has no Ruff equivalent.
-select = ["E4", "E7", "E9", "F", "UP006", "W"]
+select = ["E4", "E7", "E9", "F", "UP006", "UP035", "W"]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ target-version = "py310"
 [tool.ruff.lint]
 # Preserve Flake8's non-formatting error coverage while leaving formatter-owned
 # whitespace and line-length rules to `ruff format`. W503 has no Ruff equivalent.
-select = ["E4", "E7", "E9", "F", "UP006", "UP035", "W"]
+select = ["E4", "E7", "E9", "F", "UP006", "UP007", "UP035", "W"]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ target-version = "py310"
 [tool.ruff.lint]
 # Preserve Flake8's non-formatting error coverage while leaving formatter-owned
 # whitespace and line-length rules to `ruff format`. W503 has no Ruff equivalent.
-select = ["E4", "E7", "E9", "F", "UP006", "UP007", "UP031", "UP032", "UP035", "UP045", "W"]
+select = ["E4", "E7", "E9", "F", "UP006", "UP007", "UP031", "UP032", "UP035", "UP037", "UP045", "W"]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ target-version = "py310"
 [tool.ruff.lint]
 # Preserve Flake8's non-formatting error coverage while leaving formatter-owned
 # whitespace and line-length rules to `ruff format`. W503 has no Ruff equivalent.
-select = ["E4", "E7", "E9", "F", "UP006", "UP007", "UP035", "UP045", "W"]
+select = ["E4", "E7", "E9", "F", "UP006", "UP007", "UP031", "UP035", "UP045", "W"]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ target-version = "py310"
 [tool.ruff.lint]
 # Preserve Flake8's non-formatting error coverage while leaving formatter-owned
 # whitespace and line-length rules to `ruff format`. W503 has no Ruff equivalent.
-select = ["E4", "E7", "E9", "F", "W"]
+select = ["E4", "E7", "E9", "F", "UP006", "W"]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ target-version = "py310"
 [tool.ruff.lint]
 # Preserve Flake8's non-formatting error coverage while leaving formatter-owned
 # whitespace and line-length rules to `ruff format`. W503 has no Ruff equivalent.
-select = ["E4", "E7", "E9", "F", "UP006", "UP007", "UP031", "UP035", "UP045", "W"]
+select = ["E4", "E7", "E9", "F", "UP006", "UP007", "UP031", "UP032", "UP035", "UP045", "W"]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ target-version = "py310"
 [tool.ruff.lint]
 # Preserve Flake8's non-formatting error coverage while leaving formatter-owned
 # whitespace and line-length rules to `ruff format`. W503 has no Ruff equivalent.
-select = ["E4", "E7", "E9", "F", "UP006", "UP007", "UP035", "W"]
+select = ["E4", "E7", "E9", "F", "UP006", "UP007", "UP035", "UP045", "W"]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/src/cloup/_commands.py
+++ b/src/cloup/_commands.py
@@ -24,7 +24,6 @@ import inspect
 from typing import (
     Any,
     NamedTuple,
-    Optional,
     TypeVar,
     cast,
     overload,
@@ -72,8 +71,8 @@ class Command(ConstraintMixin, OptionGroupMixin, click.Command):
     def __init__(
         self,
         *args: Any,
-        aliases: Optional[Iterable[str]] = None,
-        formatter_settings: Optional[dict[str, Any]] = None,
+        aliases: Iterable[str] | None = None,
+        formatter_settings: dict[str, Any] | None = None,
         **kwargs: Any,
     ):
         super().__init__(*args, **kwargs)
@@ -154,10 +153,10 @@ class Group(SectionMixin, Command, click.Group):
     def __init__(
         self,
         *args: Any,
-        show_subcommand_aliases: Optional[bool] = None,
-        commands: Optional[
-            MutableMapping[str, click.Command] | Sequence[click.Command]
-        ] = None,
+        show_subcommand_aliases: bool | None = None,
+        commands: MutableMapping[str, click.Command]
+        | Sequence[click.Command]
+        | None = None,
         **kwargs: Any,
     ):
         super().__init__(*args, **kwargs)
@@ -183,8 +182,8 @@ class Group(SectionMixin, Command, click.Group):
     def add_command(
         self,
         cmd: click.Command,
-        name: Optional[str] = None,
-        section: Optional[Section] = None,
+        name: str | None = None,
+        section: Section | None = None,
         fallback_to_default_section: bool = True,
     ) -> None:
         super().add_command(cmd, name, section, fallback_to_default_section)
@@ -193,7 +192,7 @@ class Group(SectionMixin, Command, click.Group):
         for alias in aliases:
             self.alias2name[alias] = name
 
-    def resolve_command_name(self, ctx: click.Context, name: str) -> Optional[str]:
+    def resolve_command_name(self, ctx: click.Context, name: str) -> str | None:
         """Map a string supposed to be a command name or an alias to a normalized
         command name. If no match is found, it returns ``None``."""
         if ctx.token_normalize_func:
@@ -204,7 +203,7 @@ class Group(SectionMixin, Command, click.Group):
 
     def resolve_command(
         self, ctx: click.Context, args: list[str]
-    ) -> tuple[Optional[str], Optional[click.Command], list[str]]:
+    ) -> tuple[str | None, click.Command | None, list[str]]:
         normalized_name = self.resolve_command_name(ctx, args[0])
         if normalized_name:
             # Replacing this string ensures that super().resolve_command() returns a
@@ -279,54 +278,54 @@ class Group(SectionMixin, Command, click.Group):
     # pyrefly: ignore[bad-override]
     def command(  # Why overloading? Refer to module docstring.
         self,
-        name: Optional[str] = None,
+        name: str | None = None,
         *,
-        aliases: Optional[Iterable[str]] = None,
+        aliases: Iterable[str] | None = None,
         cls: None = None,  # default to Group.command_class or cloup.Command
-        section: Optional[Section] = None,
-        context_settings: Optional[dict[str, Any]] = None,
-        formatter_settings: Optional[dict[str, Any]] = None,
-        help: Optional[str] = None,
-        epilog: Optional[str] = None,
-        short_help: Optional[str] = None,
-        options_metavar: Optional[str] = "[OPTIONS]",
+        section: Section | None = None,
+        context_settings: dict[str, Any] | None = None,
+        formatter_settings: dict[str, Any] | None = None,
+        help: str | None = None,
+        epilog: str | None = None,
+        short_help: str | None = None,
+        options_metavar: str | None = "[OPTIONS]",
         add_help_option: bool = True,
         no_args_is_help: bool = False,
         hidden: bool = False,
         deprecated: bool | str = False,
-        align_option_groups: Optional[bool] = None,
-        show_constraints: Optional[bool] = None,
-        params: Optional[list[click.Parameter]] = None,
+        align_option_groups: bool | None = None,
+        show_constraints: bool | None = None,
+        params: list[click.Parameter] | None = None,
     ) -> Callable[[AnyCallable], click.Command]: ...
 
     @overload
     def command(  # Why overloading? Refer to module docstring.
         self,
-        name: Optional[str] = None,
+        name: str | None = None,
         *,
-        aliases: Optional[Iterable[str]] = None,
+        aliases: Iterable[str] | None = None,
         cls: type[C],
-        section: Optional[Section] = None,
-        context_settings: Optional[dict[str, Any]] = None,
-        help: Optional[str] = None,
-        epilog: Optional[str] = None,
-        short_help: Optional[str] = None,
-        options_metavar: Optional[str] = "[OPTIONS]",
+        section: Section | None = None,
+        context_settings: dict[str, Any] | None = None,
+        help: str | None = None,
+        epilog: str | None = None,
+        short_help: str | None = None,
+        options_metavar: str | None = "[OPTIONS]",
         add_help_option: bool = True,
         no_args_is_help: bool = False,
         hidden: bool = False,
         deprecated: bool | str = False,
-        params: Optional[list[click.Parameter]] = None,
+        params: list[click.Parameter] | None = None,
         **kwargs: Any,
     ) -> Callable[[AnyCallable], C]: ...
 
     def command(
         self,
-        name: Optional[str] = None,
+        name: str | None = None,
         *,
-        aliases: Optional[Iterable[str]] = None,
-        cls: Optional[type[C]] = None,
-        section: Optional[Section] = None,
+        aliases: Iterable[str] | None = None,
+        cls: type[C] | None = None,
+        section: Section | None = None,
         **kwargs: Any,
     ) -> Callable[[AnyCallable], click.Command | C]:
         """Return a decorator that creates a new subcommand of this ``Group``
@@ -359,25 +358,25 @@ class Group(SectionMixin, Command, click.Group):
     # pyrefly: ignore[bad-override]
     def group(  # Why overloading? Refer to module docstring.
         self,
-        name: Optional[str] = None,
+        name: str | None = None,
         *,
-        aliases: Optional[Iterable[str]] = None,
+        aliases: Iterable[str] | None = None,
         cls: None = None,  # cls not provided
-        section: Optional[Section] = None,
+        section: Section | None = None,
         sections: Iterable[Section] = (),
-        align_sections: Optional[bool] = None,
+        align_sections: bool | None = None,
         invoke_without_command: bool = False,
         no_args_is_help: bool = False,
-        context_settings: Optional[dict[str, Any]] = None,
-        formatter_settings: Optional[dict[str, Any]] = None,
-        align_option_groups: Optional[bool] = None,
-        show_constraints: Optional[bool] = None,
-        params: Optional[list[click.Parameter]] = None,
-        help: Optional[str] = None,
-        epilog: Optional[str] = None,
-        short_help: Optional[str] = None,
-        options_metavar: Optional[str] = "[OPTIONS]",
-        subcommand_metavar: Optional[str] = None,
+        context_settings: dict[str, Any] | None = None,
+        formatter_settings: dict[str, Any] | None = None,
+        align_option_groups: bool | None = None,
+        show_constraints: bool | None = None,
+        params: list[click.Parameter] | None = None,
+        help: str | None = None,
+        epilog: str | None = None,
+        short_help: str | None = None,
+        options_metavar: str | None = "[OPTIONS]",
+        subcommand_metavar: str | None = None,
         add_help_option: bool = True,
         chain: bool = False,
         hidden: bool = False,
@@ -388,34 +387,34 @@ class Group(SectionMixin, Command, click.Group):
     @overload
     def group(  # Why overloading? Refer to module docstring.
         self,
-        name: Optional[str] = None,
+        name: str | None = None,
         *,
-        aliases: Optional[Iterable[str]] = None,
+        aliases: Iterable[str] | None = None,
         cls: type[G],
-        section: Optional[Section] = None,
+        section: Section | None = None,
         invoke_without_command: bool = False,
         no_args_is_help: bool = False,
-        context_settings: Optional[dict[str, Any]] = None,
-        help: Optional[str] = None,
-        epilog: Optional[str] = None,
-        short_help: Optional[str] = None,
-        options_metavar: Optional[str] = "[OPTIONS]",
-        subcommand_metavar: Optional[str] = None,
+        context_settings: dict[str, Any] | None = None,
+        help: str | None = None,
+        epilog: str | None = None,
+        short_help: str | None = None,
+        options_metavar: str | None = "[OPTIONS]",
+        subcommand_metavar: str | None = None,
         add_help_option: bool = True,
         chain: bool = False,
         hidden: bool = False,
         deprecated: bool | str = False,
-        params: Optional[list[click.Parameter]] = None,
+        params: list[click.Parameter] | None = None,
         **kwargs: Any,
     ) -> Callable[[AnyCallable], G]: ...
 
     def group(
         self,
-        name: Optional[str] = None,
+        name: str | None = None,
         *,
-        cls: Optional[type[G]] = None,
-        aliases: Optional[Iterable[str]] = None,
-        section: Optional[Section] = None,
+        cls: type[G] | None = None,
+        aliases: Iterable[str] | None = None,
+        section: Section | None = None,
         **kwargs: Any,
     ) -> Callable[[AnyCallable], click.Group | G]:
         """Return a decorator that creates a new subcommand of this ``Group``
@@ -441,7 +440,7 @@ class Group(SectionMixin, Command, click.Group):
         return decorator
 
     @classmethod
-    def _default_group_class(cls) -> Optional[type[click.Group]]:
+    def _default_group_class(cls) -> type[click.Group] | None:
         if cls.group_class is None:
             return None
         if cls.group_class is type:
@@ -453,52 +452,52 @@ class Group(SectionMixin, Command, click.Group):
 # Why overloading? Refer to module docstring.
 @overload  # In this overload: "cls: None = None"
 def command(
-    name: Optional[str] = None,
+    name: str | None = None,
     *,
-    aliases: Optional[Iterable[str]] = None,
+    aliases: Iterable[str] | None = None,
     cls: None = None,
-    context_settings: Optional[dict[str, Any]] = None,
-    formatter_settings: Optional[dict[str, Any]] = None,
-    help: Optional[str] = None,
-    short_help: Optional[str] = None,
-    epilog: Optional[str] = None,
-    options_metavar: Optional[str] = "[OPTIONS]",
+    context_settings: dict[str, Any] | None = None,
+    formatter_settings: dict[str, Any] | None = None,
+    help: str | None = None,
+    short_help: str | None = None,
+    epilog: str | None = None,
+    options_metavar: str | None = "[OPTIONS]",
     add_help_option: bool = True,
     no_args_is_help: bool = False,
     hidden: bool = False,
     deprecated: bool | str = False,
-    align_option_groups: Optional[bool] = None,
-    show_constraints: Optional[bool] = None,
-    params: Optional[list[click.Parameter]] = None,
+    align_option_groups: bool | None = None,
+    show_constraints: bool | None = None,
+    params: list[click.Parameter] | None = None,
 ) -> Callable[[AnyCallable], Command]: ...
 
 
 @overload
 def command(  # In this overload: "cls: ClickCommand"
-    name: Optional[str] = None,
+    name: str | None = None,
     *,
-    aliases: Optional[Iterable[str]] = None,
+    aliases: Iterable[str] | None = None,
     cls: type[C],
-    context_settings: Optional[dict[str, Any]] = None,
-    help: Optional[str] = None,
-    short_help: Optional[str] = None,
-    epilog: Optional[str] = None,
-    options_metavar: Optional[str] = "[OPTIONS]",
+    context_settings: dict[str, Any] | None = None,
+    help: str | None = None,
+    short_help: str | None = None,
+    epilog: str | None = None,
+    options_metavar: str | None = "[OPTIONS]",
     add_help_option: bool = True,
     no_args_is_help: bool = False,
     hidden: bool = False,
     deprecated: bool | str = False,
-    params: Optional[list[click.Parameter]] = None,
+    params: list[click.Parameter] | None = None,
     **kwargs: Any,
 ) -> Callable[[AnyCallable], C]: ...
 
 
 # noinspection PyIncorrectDocstring
 def command(
-    name: Optional[str] = None,
+    name: str | None = None,
     *,
-    aliases: Optional[Iterable[str]] = None,
-    cls: Optional[type[C]] = None,
+    aliases: Iterable[str] | None = None,
+    cls: type[C] | None = None,
     **kwargs: Any,
 ) -> Callable[[AnyCallable], Command | C]:
     """
@@ -612,57 +611,57 @@ def command(
 
 @overload  # Why overloading? Refer to module docstring.
 def group(
-    name: Optional[str] = None,
+    name: str | None = None,
     *,
     cls: None = None,
-    aliases: Optional[Iterable[str]] = None,
+    aliases: Iterable[str] | None = None,
     sections: Iterable[Section] = (),
-    align_sections: Optional[bool] = None,
+    align_sections: bool | None = None,
     invoke_without_command: bool = False,
     no_args_is_help: bool = False,
-    context_settings: Optional[dict[str, Any]] = None,
-    formatter_settings: Optional[dict[str, Any]] = None,
-    align_option_groups: Optional[bool] = None,
-    show_constraints: Optional[bool] = None,
-    help: Optional[str] = None,
-    short_help: Optional[str] = None,
-    epilog: Optional[str] = None,
-    options_metavar: Optional[str] = "[OPTIONS]",
-    subcommand_metavar: Optional[str] = None,
+    context_settings: dict[str, Any] | None = None,
+    formatter_settings: dict[str, Any] | None = None,
+    align_option_groups: bool | None = None,
+    show_constraints: bool | None = None,
+    help: str | None = None,
+    short_help: str | None = None,
+    epilog: str | None = None,
+    options_metavar: str | None = "[OPTIONS]",
+    subcommand_metavar: str | None = None,
     add_help_option: bool = True,
     chain: bool = False,
     hidden: bool = False,
     deprecated: bool | str = False,
-    params: Optional[list[click.Parameter]] = None,
+    params: list[click.Parameter] | None = None,
     show_subcommand_aliases: bool = False,
 ) -> Callable[[AnyCallable], Group]: ...
 
 
 @overload
 def group(
-    name: Optional[str] = None,
+    name: str | None = None,
     *,
     cls: type[G],
-    aliases: Optional[Iterable[str]] = None,
+    aliases: Iterable[str] | None = None,
     invoke_without_command: bool = False,
     no_args_is_help: bool = False,
-    context_settings: Optional[dict[str, Any]] = None,
-    help: Optional[str] = None,
-    short_help: Optional[str] = None,
-    epilog: Optional[str] = None,
-    options_metavar: Optional[str] = "[OPTIONS]",
-    subcommand_metavar: Optional[str] = None,
+    context_settings: dict[str, Any] | None = None,
+    help: str | None = None,
+    short_help: str | None = None,
+    epilog: str | None = None,
+    options_metavar: str | None = "[OPTIONS]",
+    subcommand_metavar: str | None = None,
     add_help_option: bool = True,
     chain: bool = False,
     hidden: bool = False,
     deprecated: bool | str = False,
-    params: Optional[list[click.Parameter]] = None,
+    params: list[click.Parameter] | None = None,
     **kwargs: Any,
 ) -> Callable[[AnyCallable], G]: ...
 
 
 def group(
-    name: Optional[str] = None, *, cls: Optional[type[G]] = None, **kwargs: Any
+    name: str | None = None, *, cls: type[G] | None = None, **kwargs: Any
 ) -> Callable[[AnyCallable], click.Group]:
     """
     Return a decorator that instantiates a ``Group`` (or a subclass of it)

--- a/src/cloup/_commands.py
+++ b/src/cloup/_commands.py
@@ -26,7 +26,6 @@ from typing import (
     NamedTuple,
     Optional,
     TypeVar,
-    Union,
     cast,
     overload,
 )
@@ -157,7 +156,7 @@ class Group(SectionMixin, Command, click.Group):
         *args: Any,
         show_subcommand_aliases: Optional[bool] = None,
         commands: Optional[
-            Union[MutableMapping[str, click.Command], Sequence[click.Command]]
+            MutableMapping[str, click.Command] | Sequence[click.Command]
         ] = None,
         **kwargs: Any,
     ):
@@ -172,7 +171,7 @@ class Group(SectionMixin, Command, click.Group):
             self.add_multiple_commands(commands)
 
     def add_multiple_commands(
-        self, commands: Union[Mapping[str, click.Command], Sequence[click.Command]]
+        self, commands: Mapping[str, click.Command] | Sequence[click.Command]
     ) -> None:
         if isinstance(commands, Mapping):
             for name, cmd in commands.items():
@@ -294,7 +293,7 @@ class Group(SectionMixin, Command, click.Group):
         add_help_option: bool = True,
         no_args_is_help: bool = False,
         hidden: bool = False,
-        deprecated: Union[bool, str] = False,
+        deprecated: bool | str = False,
         align_option_groups: Optional[bool] = None,
         show_constraints: Optional[bool] = None,
         params: Optional[list[click.Parameter]] = None,
@@ -316,7 +315,7 @@ class Group(SectionMixin, Command, click.Group):
         add_help_option: bool = True,
         no_args_is_help: bool = False,
         hidden: bool = False,
-        deprecated: Union[bool, str] = False,
+        deprecated: bool | str = False,
         params: Optional[list[click.Parameter]] = None,
         **kwargs: Any,
     ) -> Callable[[AnyCallable], C]: ...
@@ -329,7 +328,7 @@ class Group(SectionMixin, Command, click.Group):
         cls: Optional[type[C]] = None,
         section: Optional[Section] = None,
         **kwargs: Any,
-    ) -> Callable[[AnyCallable], Union[click.Command, C]]:
+    ) -> Callable[[AnyCallable], click.Command | C]:
         """Return a decorator that creates a new subcommand of this ``Group``
         using the decorated function as callback.
 
@@ -382,7 +381,7 @@ class Group(SectionMixin, Command, click.Group):
         add_help_option: bool = True,
         chain: bool = False,
         hidden: bool = False,
-        deprecated: Union[bool, str] = False,
+        deprecated: bool | str = False,
         show_subcommand_aliases: bool = False,
     ) -> Callable[[AnyCallable], click.Group]: ...
 
@@ -405,7 +404,7 @@ class Group(SectionMixin, Command, click.Group):
         add_help_option: bool = True,
         chain: bool = False,
         hidden: bool = False,
-        deprecated: Union[bool, str] = False,
+        deprecated: bool | str = False,
         params: Optional[list[click.Parameter]] = None,
         **kwargs: Any,
     ) -> Callable[[AnyCallable], G]: ...
@@ -418,7 +417,7 @@ class Group(SectionMixin, Command, click.Group):
         aliases: Optional[Iterable[str]] = None,
         section: Optional[Section] = None,
         **kwargs: Any,
-    ) -> Callable[[AnyCallable], Union[click.Group, G]]:
+    ) -> Callable[[AnyCallable], click.Group | G]:
         """Return a decorator that creates a new subcommand of this ``Group``
         using the decorated function as callback.
 
@@ -434,7 +433,7 @@ class Group(SectionMixin, Command, click.Group):
             name=name, cls=cls or self._default_group_class(), aliases=aliases, **kwargs
         )
 
-        def decorator(f: AnyCallable) -> Union[click.Group, G]:
+        def decorator(f: AnyCallable) -> click.Group | G:
             cmd = make_group(f)
             self.add_command(cmd, section=section)
             return cmd
@@ -467,7 +466,7 @@ def command(
     add_help_option: bool = True,
     no_args_is_help: bool = False,
     hidden: bool = False,
-    deprecated: Union[bool, str] = False,
+    deprecated: bool | str = False,
     align_option_groups: Optional[bool] = None,
     show_constraints: Optional[bool] = None,
     params: Optional[list[click.Parameter]] = None,
@@ -488,7 +487,7 @@ def command(  # In this overload: "cls: ClickCommand"
     add_help_option: bool = True,
     no_args_is_help: bool = False,
     hidden: bool = False,
-    deprecated: Union[bool, str] = False,
+    deprecated: bool | str = False,
     params: Optional[list[click.Parameter]] = None,
     **kwargs: Any,
 ) -> Callable[[AnyCallable], C]: ...
@@ -501,7 +500,7 @@ def command(
     aliases: Optional[Iterable[str]] = None,
     cls: Optional[type[C]] = None,
     **kwargs: Any,
-) -> Callable[[AnyCallable], Union[Command, C]]:
+) -> Callable[[AnyCallable], Command | C]:
     """
     Return a decorator that creates a new command using the decorated function
     as callback.
@@ -588,7 +587,7 @@ def command(
             f"While parenthesis are optional in Click >= 8.1, they are required in Cloup."
         )
 
-    def decorator(f: AnyCallable) -> Union[Command, C]:
+    def decorator(f: AnyCallable) -> Command | C:
         if hasattr(f, "__cloup_constraints__"):
             if cls and not issubclass(cls, ConstraintMixin):
                 raise TypeError(
@@ -599,7 +598,7 @@ def command(
             delattr(f, "__cloup_constraints__")
             kwargs["constraints"] = constraints
 
-        cmd_cls: type[Union[Command, C]] = cls if cls is not None else Command
+        cmd_cls: type[Command | C] = cls if cls is not None else Command
         try:
             cmd = click.command(name, cls=cmd_cls, **kwargs)(f)
             if aliases:
@@ -633,7 +632,7 @@ def group(
     add_help_option: bool = True,
     chain: bool = False,
     hidden: bool = False,
-    deprecated: Union[bool, str] = False,
+    deprecated: bool | str = False,
     params: Optional[list[click.Parameter]] = None,
     show_subcommand_aliases: bool = False,
 ) -> Callable[[AnyCallable], Group]: ...
@@ -656,7 +655,7 @@ def group(
     add_help_option: bool = True,
     chain: bool = False,
     hidden: bool = False,
-    deprecated: Union[bool, str] = False,
+    deprecated: bool | str = False,
     params: Optional[list[click.Parameter]] = None,
     **kwargs: Any,
 ) -> Callable[[AnyCallable], G]: ...

--- a/src/cloup/_commands.py
+++ b/src/cloup/_commands.py
@@ -23,18 +23,14 @@ extra keywords for subclass constructors.
 import inspect
 from typing import (
     Any,
-    Callable,
-    Iterable,
     NamedTuple,
     Optional,
-    Sequence,
     TypeVar,
     Union,
     cast,
     overload,
-    MutableMapping,
-    Mapping,
 )
+from collections.abc import Callable, Iterable, Sequence, MutableMapping, Mapping
 
 import click
 

--- a/src/cloup/_commands.py
+++ b/src/cloup/_commands.py
@@ -24,14 +24,10 @@ import inspect
 from typing import (
     Any,
     Callable,
-    Dict,
     Iterable,
-    List,
     NamedTuple,
     Optional,
     Sequence,
-    Tuple,
-    Type,
     TypeVar,
     Union,
     cast,
@@ -76,20 +72,20 @@ class Command(ConstraintMixin, OptionGroupMixin, click.Command):
 
     # The Cloup command contract requires the Cloup context extensions.
     # pyrefly: ignore[bad-override-mutable-attribute]
-    context_class: Type[Context] = Context
+    context_class: type[Context] = Context
 
     def __init__(
         self,
         *args: Any,
         aliases: Optional[Iterable[str]] = None,
-        formatter_settings: Optional[Dict[str, Any]] = None,
+        formatter_settings: Optional[dict[str, Any]] = None,
         **kwargs: Any,
     ):
         super().__init__(*args, **kwargs)
         #: HelpFormatter options that are merged with ``Context.formatter_settings``
         #: (eventually overriding some values).
-        self.aliases: List[str] = [] if aliases is None else list(aliases)
-        self.formatter_settings: Dict[str, Any] = (
+        self.aliases: list[str] = [] if aliases is None else list(aliases)
+        self.formatter_settings: dict[str, Any] = (
             {} if formatter_settings is None else formatter_settings
         )
 
@@ -173,7 +169,7 @@ class Group(SectionMixin, Command, click.Group):
         self.show_subcommand_aliases = show_subcommand_aliases
         """Whether to show subcommand aliases."""
 
-        self.alias2name: Dict[str, str] = {}
+        self.alias2name: dict[str, str] = {}
         """Dictionary mapping each alias to a command name."""
 
         if commands:
@@ -212,8 +208,8 @@ class Group(SectionMixin, Command, click.Group):
         return self.alias2name.get(name)
 
     def resolve_command(
-        self, ctx: click.Context, args: List[str]
-    ) -> Tuple[Optional[str], Optional[click.Command], List[str]]:
+        self, ctx: click.Context, args: list[str]
+    ) -> tuple[Optional[str], Optional[click.Command], list[str]]:
         normalized_name = self.resolve_command_name(ctx, args[0])
         if normalized_name:
             # Replacing this string ensures that super().resolve_command() returns a
@@ -232,7 +228,7 @@ class Group(SectionMixin, Command, click.Group):
             raise new_error
 
     def handle_bad_command_name(
-        self, bad_name: str, valid_names: List[str], error: click.UsageError
+        self, bad_name: str, valid_names: list[str], error: click.UsageError
     ) -> click.UsageError:
         """This method is called when a command name cannot be resolved.
         Useful to implement the "Did you mean <x>?" feature.
@@ -293,8 +289,8 @@ class Group(SectionMixin, Command, click.Group):
         aliases: Optional[Iterable[str]] = None,
         cls: None = None,  # default to Group.command_class or cloup.Command
         section: Optional[Section] = None,
-        context_settings: Optional[Dict[str, Any]] = None,
-        formatter_settings: Optional[Dict[str, Any]] = None,
+        context_settings: Optional[dict[str, Any]] = None,
+        formatter_settings: Optional[dict[str, Any]] = None,
         help: Optional[str] = None,
         epilog: Optional[str] = None,
         short_help: Optional[str] = None,
@@ -305,7 +301,7 @@ class Group(SectionMixin, Command, click.Group):
         deprecated: Union[bool, str] = False,
         align_option_groups: Optional[bool] = None,
         show_constraints: Optional[bool] = None,
-        params: Optional[List[click.Parameter]] = None,
+        params: Optional[list[click.Parameter]] = None,
     ) -> Callable[[AnyCallable], click.Command]: ...
 
     @overload
@@ -314,9 +310,9 @@ class Group(SectionMixin, Command, click.Group):
         name: Optional[str] = None,
         *,
         aliases: Optional[Iterable[str]] = None,
-        cls: Type[C],
+        cls: type[C],
         section: Optional[Section] = None,
-        context_settings: Optional[Dict[str, Any]] = None,
+        context_settings: Optional[dict[str, Any]] = None,
         help: Optional[str] = None,
         epilog: Optional[str] = None,
         short_help: Optional[str] = None,
@@ -325,7 +321,7 @@ class Group(SectionMixin, Command, click.Group):
         no_args_is_help: bool = False,
         hidden: bool = False,
         deprecated: Union[bool, str] = False,
-        params: Optional[List[click.Parameter]] = None,
+        params: Optional[list[click.Parameter]] = None,
         **kwargs: Any,
     ) -> Callable[[AnyCallable], C]: ...
 
@@ -334,7 +330,7 @@ class Group(SectionMixin, Command, click.Group):
         name: Optional[str] = None,
         *,
         aliases: Optional[Iterable[str]] = None,
-        cls: Optional[Type[C]] = None,
+        cls: Optional[type[C]] = None,
         section: Optional[Section] = None,
         **kwargs: Any,
     ) -> Callable[[AnyCallable], Union[click.Command, C]]:
@@ -377,11 +373,11 @@ class Group(SectionMixin, Command, click.Group):
         align_sections: Optional[bool] = None,
         invoke_without_command: bool = False,
         no_args_is_help: bool = False,
-        context_settings: Optional[Dict[str, Any]] = None,
-        formatter_settings: Optional[Dict[str, Any]] = None,
+        context_settings: Optional[dict[str, Any]] = None,
+        formatter_settings: Optional[dict[str, Any]] = None,
         align_option_groups: Optional[bool] = None,
         show_constraints: Optional[bool] = None,
-        params: Optional[List[click.Parameter]] = None,
+        params: Optional[list[click.Parameter]] = None,
         help: Optional[str] = None,
         epilog: Optional[str] = None,
         short_help: Optional[str] = None,
@@ -400,11 +396,11 @@ class Group(SectionMixin, Command, click.Group):
         name: Optional[str] = None,
         *,
         aliases: Optional[Iterable[str]] = None,
-        cls: Type[G],
+        cls: type[G],
         section: Optional[Section] = None,
         invoke_without_command: bool = False,
         no_args_is_help: bool = False,
-        context_settings: Optional[Dict[str, Any]] = None,
+        context_settings: Optional[dict[str, Any]] = None,
         help: Optional[str] = None,
         epilog: Optional[str] = None,
         short_help: Optional[str] = None,
@@ -414,7 +410,7 @@ class Group(SectionMixin, Command, click.Group):
         chain: bool = False,
         hidden: bool = False,
         deprecated: Union[bool, str] = False,
-        params: Optional[List[click.Parameter]] = None,
+        params: Optional[list[click.Parameter]] = None,
         **kwargs: Any,
     ) -> Callable[[AnyCallable], G]: ...
 
@@ -422,7 +418,7 @@ class Group(SectionMixin, Command, click.Group):
         self,
         name: Optional[str] = None,
         *,
-        cls: Optional[Type[G]] = None,
+        cls: Optional[type[G]] = None,
         aliases: Optional[Iterable[str]] = None,
         section: Optional[Section] = None,
         **kwargs: Any,
@@ -450,13 +446,13 @@ class Group(SectionMixin, Command, click.Group):
         return decorator
 
     @classmethod
-    def _default_group_class(cls) -> Optional[Type[click.Group]]:
+    def _default_group_class(cls) -> Optional[type[click.Group]]:
         if cls.group_class is None:
             return None
         if cls.group_class is type:
             return cls
         else:
-            return cast(Type[click.Group], cls.group_class)
+            return cast(type[click.Group], cls.group_class)
 
 
 # Why overloading? Refer to module docstring.
@@ -466,8 +462,8 @@ def command(
     *,
     aliases: Optional[Iterable[str]] = None,
     cls: None = None,
-    context_settings: Optional[Dict[str, Any]] = None,
-    formatter_settings: Optional[Dict[str, Any]] = None,
+    context_settings: Optional[dict[str, Any]] = None,
+    formatter_settings: Optional[dict[str, Any]] = None,
     help: Optional[str] = None,
     short_help: Optional[str] = None,
     epilog: Optional[str] = None,
@@ -478,7 +474,7 @@ def command(
     deprecated: Union[bool, str] = False,
     align_option_groups: Optional[bool] = None,
     show_constraints: Optional[bool] = None,
-    params: Optional[List[click.Parameter]] = None,
+    params: Optional[list[click.Parameter]] = None,
 ) -> Callable[[AnyCallable], Command]: ...
 
 
@@ -487,8 +483,8 @@ def command(  # In this overload: "cls: ClickCommand"
     name: Optional[str] = None,
     *,
     aliases: Optional[Iterable[str]] = None,
-    cls: Type[C],
-    context_settings: Optional[Dict[str, Any]] = None,
+    cls: type[C],
+    context_settings: Optional[dict[str, Any]] = None,
     help: Optional[str] = None,
     short_help: Optional[str] = None,
     epilog: Optional[str] = None,
@@ -497,7 +493,7 @@ def command(  # In this overload: "cls: ClickCommand"
     no_args_is_help: bool = False,
     hidden: bool = False,
     deprecated: Union[bool, str] = False,
-    params: Optional[List[click.Parameter]] = None,
+    params: Optional[list[click.Parameter]] = None,
     **kwargs: Any,
 ) -> Callable[[AnyCallable], C]: ...
 
@@ -507,7 +503,7 @@ def command(
     name: Optional[str] = None,
     *,
     aliases: Optional[Iterable[str]] = None,
-    cls: Optional[Type[C]] = None,
+    cls: Optional[type[C]] = None,
     **kwargs: Any,
 ) -> Callable[[AnyCallable], Union[Command, C]]:
     """
@@ -607,7 +603,7 @@ def command(
             delattr(f, "__cloup_constraints__")
             kwargs["constraints"] = constraints
 
-        cmd_cls: Type[Union[Command, C]] = cls if cls is not None else Command
+        cmd_cls: type[Union[Command, C]] = cls if cls is not None else Command
         try:
             cmd = click.command(name, cls=cmd_cls, **kwargs)(f)
             if aliases:
@@ -629,8 +625,8 @@ def group(
     align_sections: Optional[bool] = None,
     invoke_without_command: bool = False,
     no_args_is_help: bool = False,
-    context_settings: Optional[Dict[str, Any]] = None,
-    formatter_settings: Optional[Dict[str, Any]] = None,
+    context_settings: Optional[dict[str, Any]] = None,
+    formatter_settings: Optional[dict[str, Any]] = None,
     align_option_groups: Optional[bool] = None,
     show_constraints: Optional[bool] = None,
     help: Optional[str] = None,
@@ -642,7 +638,7 @@ def group(
     chain: bool = False,
     hidden: bool = False,
     deprecated: Union[bool, str] = False,
-    params: Optional[List[click.Parameter]] = None,
+    params: Optional[list[click.Parameter]] = None,
     show_subcommand_aliases: bool = False,
 ) -> Callable[[AnyCallable], Group]: ...
 
@@ -651,11 +647,11 @@ def group(
 def group(
     name: Optional[str] = None,
     *,
-    cls: Type[G],
+    cls: type[G],
     aliases: Optional[Iterable[str]] = None,
     invoke_without_command: bool = False,
     no_args_is_help: bool = False,
-    context_settings: Optional[Dict[str, Any]] = None,
+    context_settings: Optional[dict[str, Any]] = None,
     help: Optional[str] = None,
     short_help: Optional[str] = None,
     epilog: Optional[str] = None,
@@ -665,13 +661,13 @@ def group(
     chain: bool = False,
     hidden: bool = False,
     deprecated: Union[bool, str] = False,
-    params: Optional[List[click.Parameter]] = None,
+    params: Optional[list[click.Parameter]] = None,
     **kwargs: Any,
 ) -> Callable[[AnyCallable], G]: ...
 
 
 def group(
-    name: Optional[str] = None, *, cls: Optional[Type[G]] = None, **kwargs: Any
+    name: Optional[str] = None, *, cls: Optional[type[G]] = None, **kwargs: Any
 ) -> Callable[[AnyCallable], click.Group]:
     """
     Return a decorator that instantiates a ``Group`` (or a subclass of it)
@@ -761,7 +757,7 @@ def group(
 
 class _ArgInfo(NamedTuple):
     arg_name: str
-    requires: Type[Any]
+    requires: type[Any]
     supported_by: str = ""
 
 
@@ -777,7 +773,7 @@ _ARGS_INFO = {
 
 
 def _process_unexpected_kwarg_error(
-    error: TypeError, args_info: Dict[str, _ArgInfo], cls: Type[click.Command]
+    error: TypeError, args_info: dict[str, _ArgInfo], cls: type[click.Command]
 ) -> TypeError:
     """Check if the developer tried to pass a Cloup-specific argument to a ``cls``
     that doesn't support it and if that's the case, augments the error message

--- a/src/cloup/_context.py
+++ b/src/cloup/_context.py
@@ -7,12 +7,9 @@ from typing import (
     Callable,
     Concatenate,
     cast,
-    Dict,
-    List,
     Literal,
     Optional,
     ParamSpec,
-    Type,
     TypeVar,
     overload,
 )
@@ -57,8 +54,8 @@ def pass_context(f: Callable[Concatenate[Context, P], R]) -> Callable[P, R]:
 def _warn_if_formatter_settings_conflict(
     ctx_key: str,
     formatter_key: str,
-    ctx_kwargs: Dict[str, Any],
-    formatter_settings: Dict[str, Any],
+    ctx_kwargs: dict[str, Any],
+    formatter_settings: dict[str, Any],
 ) -> None:
     if ctx_kwargs.get(ctx_key) and formatter_settings.get(formatter_key):
         from textwrap import dedent
@@ -116,7 +113,7 @@ class Context(click.Context):
 
     # The Cloup context contract requires the Cloup formatter extensions.
     # pyrefly: ignore[bad-override-mutable-attribute]
-    formatter_class: Type[HelpFormatter] = HelpFormatter
+    formatter_class: type[HelpFormatter] = HelpFormatter
 
     def __init__(
         self,
@@ -126,7 +123,7 @@ class Context(click.Context):
         show_subcommand_aliases: Optional[bool] = None,
         show_constraints: Optional[bool] = None,
         check_constraints_consistency: Optional[bool] = None,
-        formatter_settings: Dict[str, Any] = {},
+        formatter_settings: dict[str, Any] = {},
         **ctx_kwargs: Any,
     ):
         super().__init__(*ctx_args, **ctx_kwargs)
@@ -169,7 +166,7 @@ class Context(click.Context):
             **formatter_settings,
         }
 
-    def get_formatter_settings(self) -> Dict[str, Any]:
+    def get_formatter_settings(self) -> dict[str, Any]:
         return {
             "width": self.terminal_width,
             "max_width": self.max_content_width,
@@ -185,14 +182,14 @@ class Context(click.Context):
     def settings(
         *,
         auto_envvar_prefix: Possibly[str] = MISSING,
-        default_map: Possibly[Dict[str, Any]] = MISSING,
+        default_map: Possibly[dict[str, Any]] = MISSING,
         terminal_width: Possibly[int] = MISSING,
         max_content_width: Possibly[int] = MISSING,
         resilient_parsing: Possibly[bool] = MISSING,
         allow_extra_args: Possibly[bool] = MISSING,
         allow_interspersed_args: Possibly[bool] = MISSING,
         ignore_unknown_options: Possibly[bool] = MISSING,
-        help_option_names: Possibly[List[str]] = MISSING,
+        help_option_names: Possibly[list[str]] = MISSING,
         token_normalize_func: Possibly[Callable[[str], str]] = MISSING,
         color: Possibly[bool] = MISSING,
         show_default: Possibly[bool] = MISSING,
@@ -201,8 +198,8 @@ class Context(click.Context):
         show_subcommand_aliases: Possibly[bool] = MISSING,
         show_constraints: Possibly[bool] = MISSING,
         check_constraints_consistency: Possibly[bool] = MISSING,
-        formatter_settings: Possibly[Dict[str, Any]] = MISSING,
-    ) -> Dict[str, Any]:
+        formatter_settings: Possibly[dict[str, Any]] = MISSING,
+    ) -> dict[str, Any]:
         """Utility method for creating a ``context_settings`` dictionary.
 
         :param auto_envvar_prefix:

--- a/src/cloup/_context.py
+++ b/src/cloup/_context.py
@@ -4,7 +4,6 @@ import warnings
 from functools import update_wrapper
 from typing import (
     Any,
-    Callable,
     Concatenate,
     cast,
     Literal,
@@ -13,6 +12,7 @@ from typing import (
     TypeVar,
     overload,
 )
+from collections.abc import Callable
 
 import click
 

--- a/src/cloup/_context.py
+++ b/src/cloup/_context.py
@@ -32,7 +32,7 @@ def get_current_context(silent: Literal[False] = False) -> Context: ...
 def get_current_context(silent: bool) -> Context | None: ...
 
 
-def get_current_context(silent: bool = False) -> "Context | None":
+def get_current_context(silent: bool = False) -> Context | None:
     """Equivalent to :func:`click.get_current_context` but casts the returned
     :class:`click.Context` object to :class:`cloup.Context` (which is safe when using
     cloup commands classes and decorators)."""

--- a/src/cloup/_context.py
+++ b/src/cloup/_context.py
@@ -7,7 +7,6 @@ from typing import (
     Concatenate,
     cast,
     Literal,
-    Optional,
     ParamSpec,
     TypeVar,
     overload,
@@ -30,14 +29,14 @@ def get_current_context(silent: Literal[False] = False) -> Context: ...
 
 
 @overload
-def get_current_context(silent: bool) -> Optional[Context]: ...
+def get_current_context(silent: bool) -> Context | None: ...
 
 
-def get_current_context(silent: bool = False) -> "Optional[Context]":
+def get_current_context(silent: bool = False) -> "Context | None":
     """Equivalent to :func:`click.get_current_context` but casts the returned
     :class:`click.Context` object to :class:`cloup.Context` (which is safe when using
     cloup commands classes and decorators)."""
-    return cast(Optional[Context], click.get_current_context(silent=silent))
+    return cast(Context | None, click.get_current_context(silent=silent))
 
 
 def pass_context(f: Callable[Concatenate[Context, P], R]) -> Callable[P, R]:
@@ -118,11 +117,11 @@ class Context(click.Context):
     def __init__(
         self,
         *ctx_args: Any,
-        align_option_groups: Optional[bool] = None,
-        align_sections: Optional[bool] = None,
-        show_subcommand_aliases: Optional[bool] = None,
-        show_constraints: Optional[bool] = None,
-        check_constraints_consistency: Optional[bool] = None,
+        align_option_groups: bool | None = None,
+        align_sections: bool | None = None,
+        show_subcommand_aliases: bool | None = None,
+        show_constraints: bool | None = None,
+        check_constraints_consistency: bool | None = None,
         formatter_settings: dict[str, Any] = {},
         **ctx_kwargs: Any,
     ):

--- a/src/cloup/_option_groups.py
+++ b/src/cloup/_option_groups.py
@@ -5,7 +5,6 @@ Implements the "option groups" feature.
 from collections import defaultdict
 from typing import (
     Any,
-    Optional,
     overload,
 )
 from collections.abc import Callable, Iterable, Iterator, Sequence
@@ -24,8 +23,8 @@ class OptionGroup:
     def __init__(
         self,
         title: str,
-        help: Optional[str] = None,
-        constraint: Optional[Constraint] = None,
+        help: str | None = None,
+        constraint: Constraint | None = None,
         hidden: bool = False,
     ):
         """Contains the information of an option group and identifies it.
@@ -90,7 +89,7 @@ def has_option_group(param: click.Parameter) -> bool:
     return getattr(param, "group", None) is not None
 
 
-def get_option_group_of(param: click.Option) -> Optional[OptionGroup]:
+def get_option_group_of(param: click.Option) -> OptionGroup | None:
     return getattr(param, "group", None)
 
 
@@ -121,7 +120,7 @@ class OptionGroupMixin:
     """
 
     def __init__(
-        self, *args: Any, align_option_groups: Optional[bool] = None, **kwargs: Any
+        self, *args: Any, align_option_groups: bool | None = None, **kwargs: Any
     ) -> None:
         """
         :param align_option_groups:
@@ -194,7 +193,7 @@ class OptionGroupMixin:
         """Like Argument.get_help_record, but it returns a tuple even if help is empty"""
         return arg.make_metavar(ctx), getattr(arg, "help", "")
 
-    def get_arguments_help_section(self, ctx: click.Context) -> Optional[HelpSection]:
+    def get_arguments_help_section(self, ctx: click.Context) -> HelpSection | None:
         args_with_help = (arg for arg in self.arguments if getattr(arg, "help", None))
         if not any(args_with_help):
             return None
@@ -222,7 +221,7 @@ class OptionGroupMixin:
         )
 
     def must_align_option_groups(
-        self, ctx: Optional[click.Context], default: bool = True
+        self, ctx: click.Context | None, default: bool = True
     ) -> bool:
         """
         Return ``True`` if the help sections of all options groups should have
@@ -288,7 +287,7 @@ def option_group(
     title: str,
     help: str,
     *options: Decorator,
-    constraint: Optional[Constraint] = None,
+    constraint: Constraint | None = None,
     hidden: bool = False,
 ) -> Callable[[F], F]: ...
 
@@ -297,8 +296,8 @@ def option_group(
 def option_group(
     title: str,
     *options: Decorator,
-    help: Optional[str] = None,
-    constraint: Optional[Constraint] = None,
+    help: str | None = None,
+    constraint: Constraint | None = None,
     hidden: bool = False,
 ) -> Callable[[F], F]: ...
 
@@ -349,8 +348,8 @@ def option_group(title: str, *args: Any, **kwargs: Any) -> Callable[[F], F]:
 def _option_group(
     title: str,
     options: Sequence[Callable[[F], F]],
-    help: Optional[str] = None,
-    constraint: Optional[Constraint] = None,
+    help: str | None = None,
+    constraint: Constraint | None = None,
     hidden: bool = False,
 ) -> Callable[[F], F]:
     if not isinstance(title, str):

--- a/src/cloup/_option_groups.py
+++ b/src/cloup/_option_groups.py
@@ -6,13 +6,10 @@ from collections import defaultdict
 from typing import (
     Any,
     Callable,
-    Dict,
     Iterable,
     Iterator,
-    List,
     Optional,
     Sequence,
-    Tuple,
     overload,
 )
 
@@ -65,7 +62,7 @@ class OptionGroup:
         elif all(opt.hidden for opt in opts):
             self.hidden = True
 
-    def get_help_records(self, ctx: click.Context) -> List[Tuple[str, str]]:
+    def get_help_records(self, ctx: click.Context) -> list[tuple[str, str]]:
         if self.hidden:
             return []
         return [
@@ -162,12 +159,12 @@ class OptionGroupMixin:
 
     @staticmethod
     def _group_params(
-        params: List[Parameter],
-    ) -> Tuple[List[click.Argument], List[OptionGroup], List[Option]]:
+        params: list[Parameter],
+    ) -> tuple[list[click.Argument], list[OptionGroup], list[Option]]:
 
-        options_by_group: Dict[OptionGroup, List[click.Option]] = defaultdict(list)
-        arguments: List[click.Argument] = []
-        ungrouped_options: List[click.Option] = []
+        options_by_group: dict[OptionGroup, list[click.Option]] = defaultdict(list)
+        arguments: list[click.Argument] = []
+        ungrouped_options: list[click.Option] = []
         for param in params:
             if isinstance(param, click.Argument):
                 arguments.append(param)
@@ -196,7 +193,7 @@ class OptionGroupMixin:
 
     def get_argument_help_record(
         self, arg: click.Argument, ctx: click.Context
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         """Like Argument.get_help_record, but it returns a tuple even if help is empty"""
         return arg.make_metavar(ctx), getattr(arg, "help", "")
 

--- a/src/cloup/_option_groups.py
+++ b/src/cloup/_option_groups.py
@@ -5,13 +5,10 @@ Implements the "option groups" feature.
 from collections import defaultdict
 from typing import (
     Any,
-    Callable,
-    Iterable,
-    Iterator,
     Optional,
-    Sequence,
     overload,
 )
+from collections.abc import Callable, Iterable, Iterator, Sequence
 
 import click
 from click import Option, Parameter

--- a/src/cloup/_params.py
+++ b/src/cloup/_params.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import click
 from click.decorators import _param_memo
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 class Option(click.Option):
     """A :class:`click.Option` with an extra field ``group`` of type ``OptionGroup``."""
 
-    group: Optional[OptionGroup]
+    group: OptionGroup | None
 
     def __init__(self, *args, group=None, **attrs):
         super().__init__(*args, **attrs)

--- a/src/cloup/_params.pyi
+++ b/src/cloup/_params.pyi
@@ -4,12 +4,11 @@ Types for parameter decorators are in this stub for convenience of implementatio
 
 from typing import (
     Any,
-    Callable,
     Optional,
-    Sequence,
     TypeVar,
     Union,
 )
+from collections.abc import Callable, Sequence
 
 import click
 from click.shell_completion import CompletionItem

--- a/src/cloup/_params.pyi
+++ b/src/cloup/_params.pyi
@@ -6,7 +6,6 @@ from typing import (
     Any,
     Optional,
     TypeVar,
-    Union,
 )
 from collections.abc import Callable, Sequence
 
@@ -18,13 +17,13 @@ from cloup import OptionGroup
 F = TypeVar("F", bound=Callable[..., Any])
 P = TypeVar("P", bound=click.Parameter)
 
-SimpleParamTypeLike = Union[click.ParamType[Any], Callable[[str], Any]]
-ParamTypeLike = Union[SimpleParamTypeLike, tuple[SimpleParamTypeLike, ...]]
-ParamDefault = Union[Any, Callable[[], Any]]
+SimpleParamTypeLike = click.ParamType[Any] | Callable[[str], Any]
+ParamTypeLike = SimpleParamTypeLike | tuple[SimpleParamTypeLike, ...]
+ParamDefault = Any | Callable[[], Any]
 ParamCallback = Callable[[click.Context, P, Any], Any]
 ShellCompleteArg = Callable[
     [click.Context, P, str],
-    Union[list[CompletionItem], list[str]],
+    list[CompletionItem] | list[str],
 ]
 
 class Option(click.Option):
@@ -44,7 +43,7 @@ def argument(
     nargs: Optional[int] = None,
     metavar: Optional[str] = None,
     expose_value: bool = True,
-    envvar: Optional[Union[str, Sequence[str]]] = None,
+    envvar: Optional[str | Sequence[str]] = None,
     shell_complete: Optional[ShellCompleteArg[click.Argument]] = None,
     **kwargs: Any,
 ) -> Callable[[F], F]: ...
@@ -64,7 +63,7 @@ def option(
     is_eager: bool = False,
     # Help text tuning
     show_choices: bool = True,
-    show_default: Union[bool, str, None] = None,
+    show_default: bool | str | None = None,
     show_envvar: bool = False,
     # Flag options
     flag_value: Optional[Any] = None,
@@ -73,13 +72,13 @@ def option(
     nargs: Optional[int] = None,
     multiple: bool = False,
     # Prompt
-    prompt: Union[bool, str] = False,
-    confirmation_prompt: Union[bool, str] = False,
+    prompt: bool | str = False,
+    confirmation_prompt: bool | str = False,
     prompt_required: bool = True,
     hide_input: bool = False,
     # Environment
     allow_from_autoenv: bool = True,
-    envvar: Optional[Union[str, Sequence[str]]] = None,
+    envvar: Optional[str | Sequence[str]] = None,
     # Hiding
     hidden: bool = False,
     expose_value: bool = True,

--- a/src/cloup/_params.pyi
+++ b/src/cloup/_params.pyi
@@ -5,11 +5,8 @@ Types for parameter decorators are in this stub for convenience of implementatio
 from typing import (
     Any,
     Callable,
-    List,
     Optional,
     Sequence,
-    Tuple,
-    Type,
     TypeVar,
     Union,
 )
@@ -23,12 +20,12 @@ F = TypeVar("F", bound=Callable[..., Any])
 P = TypeVar("P", bound=click.Parameter)
 
 SimpleParamTypeLike = Union[click.ParamType[Any], Callable[[str], Any]]
-ParamTypeLike = Union[SimpleParamTypeLike, Tuple[SimpleParamTypeLike, ...]]
+ParamTypeLike = Union[SimpleParamTypeLike, tuple[SimpleParamTypeLike, ...]]
 ParamDefault = Union[Any, Callable[[], Any]]
 ParamCallback = Callable[[click.Context, P, Any], Any]
 ShellCompleteArg = Callable[
     [click.Context, P, str],
-    Union[List[CompletionItem], List[str]],
+    Union[list[CompletionItem], list[str]],
 ]
 
 class Option(click.Option):
@@ -38,7 +35,7 @@ class Option(click.Option):
 
 def argument(
     *param_decls: str,
-    cls: Optional[Type[click.Argument]] = None,
+    cls: Optional[type[click.Argument]] = None,
     help: Optional[str] = None,
     deprecated: bool | str = False,
     type: Optional[ParamTypeLike] = None,
@@ -54,7 +51,7 @@ def argument(
 ) -> Callable[[F], F]: ...
 def option(
     *param_decls: str,
-    cls: Optional[Type[click.Option]] = None,
+    cls: Optional[type[click.Option]] = None,
     # Commonly used
     metavar: Optional[str] = None,
     type: Optional[ParamTypeLike] = None,

--- a/src/cloup/_params.pyi
+++ b/src/cloup/_params.pyi
@@ -4,7 +4,6 @@ Types for parameter decorators are in this stub for convenience of implementatio
 
 from typing import (
     Any,
-    Optional,
     TypeVar,
 )
 from collections.abc import Callable, Sequence
@@ -27,49 +26,49 @@ ShellCompleteArg = Callable[
 ]
 
 class Option(click.Option):
-    group: Optional[OptionGroup]
+    group: OptionGroup | None
 
-    def __init__(self, *args: Any, group: Optional[OptionGroup] = None, **attrs: Any): ...
+    def __init__(self, *args: Any, group: OptionGroup | None = None, **attrs: Any): ...
 
 def argument(
     *param_decls: str,
-    cls: Optional[type[click.Argument]] = None,
-    help: Optional[str] = None,
+    cls: type[click.Argument] | None = None,
+    help: str | None = None,
     deprecated: bool | str = False,
-    type: Optional[ParamTypeLike] = None,
-    required: Optional[bool] = None,
-    default: Optional[ParamDefault] = None,
-    callback: Optional[ParamCallback[click.Argument]] = None,
-    nargs: Optional[int] = None,
-    metavar: Optional[str] = None,
+    type: ParamTypeLike | None = None,
+    required: bool | None = None,
+    default: ParamDefault | None = None,
+    callback: ParamCallback[click.Argument] | None = None,
+    nargs: int | None = None,
+    metavar: str | None = None,
     expose_value: bool = True,
-    envvar: Optional[str | Sequence[str]] = None,
-    shell_complete: Optional[ShellCompleteArg[click.Argument]] = None,
+    envvar: str | Sequence[str] | None = None,
+    shell_complete: ShellCompleteArg[click.Argument] | None = None,
     **kwargs: Any,
 ) -> Callable[[F], F]: ...
 def option(
     *param_decls: str,
-    cls: Optional[type[click.Option]] = None,
+    cls: type[click.Option] | None = None,
     # Commonly used
-    metavar: Optional[str] = None,
-    type: Optional[ParamTypeLike] = None,
-    is_flag: Optional[bool] = None,
-    default: Optional[ParamDefault] = None,
-    required: Optional[bool] = None,
-    help: Optional[str] = None,
+    metavar: str | None = None,
+    type: ParamTypeLike | None = None,
+    is_flag: bool | None = None,
+    default: ParamDefault | None = None,
+    required: bool | None = None,
+    help: str | None = None,
     deprecated: bool | str = False,
     # Processing
-    callback: Optional[ParamCallback[click.Option]] = None,
+    callback: ParamCallback[click.Option] | None = None,
     is_eager: bool = False,
     # Help text tuning
     show_choices: bool = True,
     show_default: bool | str | None = None,
     show_envvar: bool = False,
     # Flag options
-    flag_value: Optional[Any] = None,
+    flag_value: Any | None = None,
     count: bool = False,
     # Multiple values
-    nargs: Optional[int] = None,
+    nargs: int | None = None,
     multiple: bool = False,
     # Prompt
     prompt: bool | str = False,
@@ -78,12 +77,12 @@ def option(
     hide_input: bool = False,
     # Environment
     allow_from_autoenv: bool = True,
-    envvar: Optional[str | Sequence[str]] = None,
+    envvar: str | Sequence[str] | None = None,
     # Hiding
     hidden: bool = False,
     expose_value: bool = True,
     # Others
-    group: Optional[OptionGroup] = None,
-    shell_complete: Optional[ShellCompleteArg[click.Option]] = None,
+    group: OptionGroup | None = None,
+    shell_complete: ShellCompleteArg[click.Option] | None = None,
     **kwargs: Any,
 ) -> Callable[[F], F]: ...

--- a/src/cloup/_sections.py
+++ b/src/cloup/_sections.py
@@ -3,7 +3,6 @@ from typing import (
     Any,
     Optional,
     TypeVar,
-    Union,
 )
 from collections.abc import Iterable, Sequence
 
@@ -13,7 +12,7 @@ from cloup._util import first_bool, pick_not_none
 from cloup.formatting import HelpSection, ensure_is_cloup_formatter
 
 CommandType = TypeVar("CommandType", bound=type[click.Command])
-Subcommands = Union[Sequence[click.Command], dict[str, click.Command]]
+Subcommands = Sequence[click.Command] | dict[str, click.Command]
 
 
 class Section:

--- a/src/cloup/_sections.py
+++ b/src/cloup/_sections.py
@@ -1,7 +1,6 @@
 from collections import OrderedDict
 from typing import (
     Any,
-    Optional,
     TypeVar,
 )
 from collections.abc import Iterable, Sequence
@@ -58,7 +57,7 @@ class Section:
     def sorted(cls, title: str, commands: Subcommands = ()) -> "Section":
         return cls(title, commands, is_sorted=True)
 
-    def add_command(self, cmd: click.Command, name: Optional[str] = None) -> None:
+    def add_command(self, cmd: click.Command, name: str | None = None) -> None:
         name = name or cmd.name
         if not name:
             raise TypeError("missing command name")
@@ -111,9 +110,9 @@ class SectionMixin:
     def __init__(
         self,
         *args: Any,
-        commands: Optional[dict[str, click.Command]] = None,
+        commands: dict[str, click.Command] | None = None,
         sections: Iterable[Section] = (),
-        align_sections: Optional[bool] = None,
+        align_sections: bool | None = None,
         **kwargs: Any,
     ):
         """
@@ -139,8 +138,8 @@ class SectionMixin:
     def _add_command_to_section(
         self,
         cmd: click.Command,
-        name: Optional[str] = None,
-        section: Optional[Section] = None,
+        name: str | None = None,
+        section: Section | None = None,
     ) -> None:
         """Add a command to the section (if specified) or to the default section."""
         name = name or cmd.name
@@ -176,8 +175,8 @@ class SectionMixin:
     def add_command(
         self,
         cmd: click.Command,
-        name: Optional[str] = None,
-        section: Optional[Section] = None,
+        name: str | None = None,
+        section: Section | None = None,
         fallback_to_default_section: bool = True,
     ) -> None:
         """
@@ -233,7 +232,7 @@ class SectionMixin:
 
     def make_commands_help_section(
         self, ctx: click.Context, section: Section
-    ) -> Optional[HelpSection]:
+    ) -> HelpSection | None:
         visible_subcommands = section.list_commands()
         if not visible_subcommands:
             return None
@@ -246,7 +245,7 @@ class SectionMixin:
         )
 
     def must_align_sections(
-        self, ctx: Optional[click.Context], default: bool = True
+        self, ctx: click.Context | None, default: bool = True
     ) -> bool:
         return first_bool(
             self.align_sections,

--- a/src/cloup/_sections.py
+++ b/src/cloup/_sections.py
@@ -1,13 +1,9 @@
 from collections import OrderedDict
 from typing import (
     Any,
-    Dict,
     Iterable,
-    List,
     Optional,
     Sequence,
-    Tuple,
-    Type,
     TypeVar,
     Union,
 )
@@ -17,8 +13,8 @@ import click
 from cloup._util import first_bool, pick_not_none
 from cloup.formatting import HelpSection, ensure_is_cloup_formatter
 
-CommandType = TypeVar("CommandType", bound=Type[click.Command])
-Subcommands = Union[Sequence[click.Command], Dict[str, click.Command]]
+CommandType = TypeVar("CommandType", bound=type[click.Command])
+Subcommands = Union[Sequence[click.Command], dict[str, click.Command]]
 
 
 class Section:
@@ -72,7 +68,7 @@ class Section:
             raise Exception(f'command "{name}" already exists')
         self.commands[name] = cmd
 
-    def list_commands(self) -> List[Tuple[str, click.Command]]:
+    def list_commands(self) -> list[tuple[str, click.Command]]:
         command_list = [
             (name, cmd) for name, cmd in self.commands.items() if not cmd.hidden
         ]
@@ -117,7 +113,7 @@ class SectionMixin:
     def __init__(
         self,
         *args: Any,
-        commands: Optional[Dict[str, click.Command]] = None,
+        commands: Optional[dict[str, click.Command]] = None,
         sections: Iterable[Section] = (),
         align_sections: Optional[bool] = None,
         **kwargs: Any,
@@ -137,7 +133,7 @@ class SectionMixin:
         super().__init__(*args, commands=commands, **kwargs)  # type: ignore
         self.align_sections = align_sections
         self._default_section = Section("__DEFAULT", commands=commands or [])
-        self._user_sections: List[Section] = []
+        self._user_sections: list[Section] = []
         self._section_set = {self._default_section}
         for section in sections:
             self.add_section(section)
@@ -210,7 +206,7 @@ class SectionMixin:
 
     def list_sections(
         self, ctx: click.Context, include_default_section: bool = True
-    ) -> List[Section]:
+    ) -> list[Section]:
         """
         Return the list of all sections in the "correct order".
 

--- a/src/cloup/_sections.py
+++ b/src/cloup/_sections.py
@@ -77,7 +77,7 @@ class Section:
         return len(self.commands)
 
     def __repr__(self) -> str:
-        return "Section({}, is_sorted={})".format(self.title, self.is_sorted)
+        return f"Section({self.title}, is_sorted={self.is_sorted})"
 
 
 class SectionMixin:

--- a/src/cloup/_sections.py
+++ b/src/cloup/_sections.py
@@ -1,12 +1,11 @@
 from collections import OrderedDict
 from typing import (
     Any,
-    Iterable,
     Optional,
-    Sequence,
     TypeVar,
     Union,
 )
+from collections.abc import Iterable, Sequence
 
 import click
 

--- a/src/cloup/_util.py
+++ b/src/cloup/_util.py
@@ -3,13 +3,10 @@
 import importlib.metadata
 from typing import (
     Any,
-    Dict,
     Hashable,
     Iterable,
-    List,
     Optional,
     Sequence,
-    Type,
     TypeVar,
 )
 
@@ -24,7 +21,7 @@ K = TypeVar("K", bound=Hashable)
 V = TypeVar("V")
 
 
-def pick_non_missing(d: Dict[K, Possibly[V]]) -> Dict[K, V]:
+def pick_non_missing(d: dict[K, Possibly[V]]) -> dict[K, V]:
     return {key: val for key, val in d.items() if val is not MISSING}
 
 
@@ -37,7 +34,7 @@ def check_arg(condition: bool, msg: str = "") -> None:
         raise ValueError(msg)
 
 
-def indent_lines(lines: Iterable[str], width: int = 2) -> List[str]:
+def indent_lines(lines: Iterable[str], width: int = 2) -> list[str]:
     spaces = " " * width
     return [spaces + line for line in lines]
 
@@ -105,12 +102,12 @@ def first_bool(*values: Any) -> bool:
     return next(val for val in values if isinstance(val, bool))
 
 
-def pick_not_none(iterable: Iterable[Optional[T]]) -> List[T]:
+def pick_not_none(iterable: Iterable[Optional[T]]) -> list[T]:
     return [x for x in iterable if x is not None]
 
 
 def check_positive_int(value: Any, arg_name: str) -> None:
-    error_type: Optional[Type[Exception]] = None
+    error_type: Optional[type[Exception]] = None
     if not isinstance(value, int):
         error_type = TypeError
     elif value <= 0:
@@ -140,7 +137,7 @@ class FrozenSpaceMeta(type):
                 "(e.g. __annotations__) are allowed to be set for compatibility reasons."
             )
 
-    def asdict(cls) -> Dict[str, Any]:
+    def asdict(cls) -> dict[str, Any]:
         return cls._dict  # type: ignore
 
     def __contains__(cls, item: str) -> bool:
@@ -159,7 +156,7 @@ class FrozenSpace(metaclass=FrozenSpaceMeta):
         )
 
 
-def delete_keys(d: Dict[Any, Any], keys: Sequence[str]) -> None:
+def delete_keys(d: dict[Any, Any], keys: Sequence[str]) -> None:
     for key in keys:
         del d[key]
 

--- a/src/cloup/_util.py
+++ b/src/cloup/_util.py
@@ -3,7 +3,6 @@
 import importlib.metadata
 from typing import (
     Any,
-    Optional,
     TypeVar,
 )
 from collections.abc import Hashable, Iterable, Sequence
@@ -89,7 +88,7 @@ def pluralize(
     return many.format(count=count)
 
 
-def coalesce(*values: Optional[T]) -> Optional[T]:
+def coalesce(*values: T | None) -> T | None:
     """Return the first value that is not ``None``
     (or ``None`` if no such value exists)."""
     return next((val for val in values if val is not None), None)
@@ -100,12 +99,12 @@ def first_bool(*values: Any) -> bool:
     return next(val for val in values if isinstance(val, bool))
 
 
-def pick_not_none(iterable: Iterable[Optional[T]]) -> list[T]:
+def pick_not_none(iterable: Iterable[T | None]) -> list[T]:
     return [x for x in iterable if x is not None]
 
 
 def check_positive_int(value: Any, arg_name: str) -> None:
-    error_type: Optional[type[Exception]] = None
+    error_type: type[Exception] | None = None
     if not isinstance(value, int):
         error_type = TypeError
     elif value <= 0:

--- a/src/cloup/_util.py
+++ b/src/cloup/_util.py
@@ -3,12 +3,10 @@
 import importlib.metadata
 from typing import (
     Any,
-    Hashable,
-    Iterable,
     Optional,
-    Sequence,
     TypeVar,
 )
+from collections.abc import Hashable, Iterable, Sequence
 
 from cloup.typing import MISSING, Possibly
 

--- a/src/cloup/constraints/_conditional.py
+++ b/src/cloup/constraints/_conditional.py
@@ -2,7 +2,7 @@
 This modules contains classes for creating conditional constraints.
 """
 
-from typing import Optional, Union
+from typing import Optional
 from collections.abc import Sequence
 
 from click import Context, Parameter
@@ -13,7 +13,7 @@ from .exceptions import ConstraintViolated
 from .._util import make_repr
 
 
-def as_predicate(arg: Union[str, Sequence[str], Predicate]) -> Predicate:
+def as_predicate(arg: str | Sequence[str] | Predicate) -> Predicate:
     if isinstance(arg, str):
         return IsSet(arg)
     elif isinstance(arg, Predicate):
@@ -44,7 +44,7 @@ class If(Constraint):
 
     def __init__(
         self,
-        condition: Union[str, Sequence[str], Predicate],
+        condition: str | Sequence[str] | Predicate,
         then: Constraint,
         else_: Optional[Constraint] = None,
     ):

--- a/src/cloup/constraints/_conditional.py
+++ b/src/cloup/constraints/_conditional.py
@@ -2,7 +2,6 @@
 This modules contains classes for creating conditional constraints.
 """
 
-from typing import Optional
 from collections.abc import Sequence
 
 from click import Context, Parameter
@@ -46,7 +45,7 @@ class If(Constraint):
         self,
         condition: str | Sequence[str] | Predicate,
         then: Constraint,
-        else_: Optional[Constraint] = None,
+        else_: Constraint | None = None,
     ):
         self._condition = as_predicate(condition)
         self._then = then

--- a/src/cloup/constraints/_conditional.py
+++ b/src/cloup/constraints/_conditional.py
@@ -2,7 +2,8 @@
 This modules contains classes for creating conditional constraints.
 """
 
-from typing import Optional, Sequence, Union
+from typing import Optional, Union
+from collections.abc import Sequence
 
 from click import Context, Parameter
 

--- a/src/cloup/constraints/_core.py
+++ b/src/cloup/constraints/_core.py
@@ -255,7 +255,7 @@ class Operator(Constraint, abc.ABC):
 
     def help(self, ctx: click.Context) -> str:
         return self.HELP_SEP.join(
-            "(%s)" % c.help(ctx) if isinstance(c, Operator) else c.help(ctx)
+            "({})".format(c.help(ctx)) if isinstance(c, Operator) else c.help(ctx)
             for c in self.constraints
         )
 

--- a/src/cloup/constraints/_core.py
+++ b/src/cloup/constraints/_core.py
@@ -255,7 +255,7 @@ class Operator(Constraint, abc.ABC):
 
     def help(self, ctx: click.Context) -> str:
         return self.HELP_SEP.join(
-            "({})".format(c.help(ctx)) if isinstance(c, Operator) else c.help(ctx)
+            f"({c.help(ctx)})" if isinstance(c, Operator) else c.help(ctx)
             for c in self.constraints
         )
 

--- a/src/cloup/constraints/_core.py
+++ b/src/cloup/constraints/_core.py
@@ -3,7 +3,6 @@ from typing import (
     Any,
     Optional,
     TypeVar,
-    Union,
     cast,
     overload,
 )
@@ -127,7 +126,7 @@ class Constraint(abc.ABC):
 
     def check(
         self,
-        params: Union[Sequence[click.Parameter], Sequence[str]],
+        params: Sequence[click.Parameter] | Sequence[str],
         ctx: Optional[click.Context] = None,
     ) -> None:
         """
@@ -176,8 +175,8 @@ class Constraint(abc.ABC):
 
     def rephrased(
         self,
-        help: Union[None, str, HelpRephraser] = None,
-        error: Union[None, str, ErrorRephraser] = None,
+        help: None | str | HelpRephraser = None,
+        error: None | str | ErrorRephraser = None,
     ) -> "Rephraser":
         """
         Override the help string and/or the error message of this constraint
@@ -345,8 +344,8 @@ class Rephraser(Constraint):
     def __init__(
         self,
         constraint: Constraint,
-        help: Union[None, str, HelpRephraser] = None,
-        error: Union[None, str, ErrorRephraser] = None,
+        help: None | str | HelpRephraser = None,
+        error: None | str | ErrorRephraser = None,
     ):
         if help is None and error is None:
             raise ValueError("`help` and `error` cannot both be `None`")

--- a/src/cloup/constraints/_core.py
+++ b/src/cloup/constraints/_core.py
@@ -1,14 +1,13 @@
 import abc
 from typing import (
     Any,
-    Callable,
     Optional,
-    Sequence,
     TypeVar,
     Union,
     cast,
     overload,
 )
+from collections.abc import Callable, Sequence
 
 import click
 

--- a/src/cloup/constraints/_core.py
+++ b/src/cloup/constraints/_core.py
@@ -1,7 +1,6 @@
 import abc
 from typing import (
     Any,
-    Optional,
     TypeVar,
     cast,
     overload,
@@ -116,18 +115,16 @@ class Constraint(abc.ABC):
 
     @overload
     def check(
-        self, params: Sequence[click.Parameter], ctx: Optional[click.Context] = None
+        self, params: Sequence[click.Parameter], ctx: click.Context | None = None
     ) -> None: ...
 
     @overload
-    def check(
-        self, params: Sequence[str], ctx: Optional[click.Context] = None
-    ) -> None: ...
+    def check(self, params: Sequence[str], ctx: click.Context | None = None) -> None: ...
 
     def check(
         self,
         params: Sequence[click.Parameter] | Sequence[str],
-        ctx: Optional[click.Context] = None,
+        ctx: click.Context | None = None,
     ) -> None:
         """
         Raise an exception if the constraint is not satisfied by the input
@@ -361,7 +358,7 @@ class Rephraser(Constraint):
         else:
             return self._help(ctx, self.constraint)
 
-    def _get_rephrased_error(self, err: ConstraintViolated) -> Optional[str]:
+    def _get_rephrased_error(self, err: ConstraintViolated) -> str | None:
         if self._error is None:
             return None
         elif isinstance(self._error, str):

--- a/src/cloup/constraints/_support.py
+++ b/src/cloup/constraints/_support.py
@@ -1,7 +1,6 @@
 from typing import (
     Any,
     NamedTuple,
-    Optional,
     TYPE_CHECKING,
     Union,
 )
@@ -112,7 +111,7 @@ class BoundConstraint(NamedTuple):
     def check_values(self, ctx: click.Context) -> None:
         self.constraint.check_values(self.params, ctx)
 
-    def get_help_record(self, ctx: click.Context) -> Optional[tuple[str, str]]:
+    def get_help_record(self, ctx: click.Context) -> tuple[str, str] | None:
         constr_help = self.constraint.help(ctx)
         if not constr_help:
             return None
@@ -127,7 +126,7 @@ class ConstraintMixin:
         self,
         *args: Any,
         constraints: Sequence[BoundConstraintSpec | BoundConstraint] = (),
-        show_constraints: Optional[bool] = None,
+        show_constraints: bool | None = None,
         **kwargs: Any,
     ):
         """

--- a/src/cloup/constraints/_support.py
+++ b/src/cloup/constraints/_support.py
@@ -126,7 +126,7 @@ class ConstraintMixin:
     def __init__(
         self,
         *args: Any,
-        constraints: Sequence[Union[BoundConstraintSpec, BoundConstraint]] = (),
+        constraints: Sequence[BoundConstraintSpec | BoundConstraint] = (),
         show_constraints: Optional[bool] = None,
         **kwargs: Any,
     ):

--- a/src/cloup/constraints/_support.py
+++ b/src/cloup/constraints/_support.py
@@ -1,13 +1,11 @@
 from typing import (
     Any,
-    Callable,
-    Iterable,
     NamedTuple,
     Optional,
-    Sequence,
     TYPE_CHECKING,
     Union,
 )
+from collections.abc import Callable, Iterable, Sequence
 
 import click
 

--- a/src/cloup/constraints/_support.py
+++ b/src/cloup/constraints/_support.py
@@ -115,7 +115,7 @@ class BoundConstraint(NamedTuple):
         constr_help = self.constraint.help(ctx)
         if not constr_help:
             return None
-        param_list = "{%s}" % join_param_labels(self.params)
+        param_list = "{{{}}}".format(join_param_labels(self.params))
         return param_list, constr_help
 
 

--- a/src/cloup/constraints/_support.py
+++ b/src/cloup/constraints/_support.py
@@ -1,14 +1,11 @@
 from typing import (
     Any,
     Callable,
-    Dict,
     Iterable,
-    List,
     NamedTuple,
     Optional,
     Sequence,
     TYPE_CHECKING,
-    Tuple,
     Union,
 )
 
@@ -117,7 +114,7 @@ class BoundConstraint(NamedTuple):
     def check_values(self, ctx: click.Context) -> None:
         self.constraint.check_values(self.params, ctx)
 
-    def get_help_record(self, ctx: click.Context) -> Optional[Tuple[str, str]]:
+    def get_help_record(self, ctx: click.Context) -> Optional[tuple[str, str]]:
         constr_help = self.constraint.help(ctx)
         if not constr_help:
             return None
@@ -155,14 +152,14 @@ class ConstraintMixin:
         self.show_constraints = show_constraints
 
         # This allows constraints to efficiently access parameters by name
-        self._params_by_name: Dict[str, click.Parameter] = {
+        self._params_by_name: dict[str, click.Parameter] = {
             param.name: param
             for param in self.params  # type: ignore
         }
 
         # Collect constraints applied to option groups and bind them to the
         # corresponding Option instances
-        option_groups: Tuple[OptionGroup, ...] = getattr(self, "option_groups", tuple())
+        option_groups: tuple[OptionGroup, ...] = getattr(self, "option_groups", tuple())
         self.optgroup_constraints = tuple(
             BoundConstraint(grp.constraint, grp.options)
             for grp in option_groups
@@ -171,7 +168,7 @@ class ConstraintMixin:
         """Constraints applied to ``OptionGroup`` instances."""
 
         # Bind constraints defined via @constraint to click.Parameter instances
-        self.param_constraints: Tuple[BoundConstraint, ...] = tuple(
+        self.param_constraints: tuple[BoundConstraint, ...] = tuple(
             (
                 constr
                 if isinstance(constr, BoundConstraint)
@@ -184,7 +181,7 @@ class ConstraintMixin:
         self.all_constraints = self.optgroup_constraints + self.param_constraints
         """All constraints applied to parameter/option groups of this command."""
 
-    def parse_args(self, ctx: click.Context, args: List[str]) -> List[str]:
+    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
         # Check constraints' consistency *before* parsing
         if not ctx.resilient_parsing and Constraint.must_check_consistency(ctx):
             for constr in self.all_constraints:

--- a/src/cloup/constraints/_support.py
+++ b/src/cloup/constraints/_support.py
@@ -115,7 +115,7 @@ class BoundConstraint(NamedTuple):
         constr_help = self.constraint.help(ctx)
         if not constr_help:
             return None
-        param_list = "{{{}}}".format(join_param_labels(self.params))
+        param_list = f"{{{join_param_labels(self.params)}}}"
         return param_list, constr_help
 
 

--- a/src/cloup/constraints/common.py
+++ b/src/cloup/constraints/common.py
@@ -2,7 +2,7 @@
 Useful functions used to implement constraints and predicates.
 """
 
-from typing import Any, Dict, Iterable, List, Sequence
+from typing import Any, Iterable, Sequence
 
 from click import Argument, Context, Option, Parameter
 
@@ -42,14 +42,14 @@ def get_param_name(param: Parameter) -> str:
 
 
 def get_params_whose_value_is_set(
-    params: Iterable[Parameter], values: Dict[str, Any]
-) -> List[Parameter]:
+    params: Iterable[Parameter], values: dict[str, Any]
+) -> list[Parameter]:
     """Filter ``params``, returning only the parameters that have a value.
     Boolean flags are considered "set" if their value is ``True``."""
     return [p for p in params if param_value_is_set(p, values[get_param_name(p)])]
 
 
-def get_required_params(params: Iterable[Parameter]) -> List[Parameter]:
+def get_required_params(params: Iterable[Parameter]) -> list[Parameter]:
     return [p for p in params if p.required]
 
 
@@ -98,7 +98,7 @@ def param_label_by_name(ctx: Any, name: str) -> str:
     return get_param_label(ctx.command.get_param_by_name(name))
 
 
-def get_param_labels(ctx: Any, param_names: Iterable[str]) -> List[str]:
+def get_param_labels(ctx: Any, param_names: Iterable[str]) -> list[str]:
     params = ctx.command.get_params_by_name(param_names)
     return [get_param_label(param) for param in params]
 

--- a/src/cloup/constraints/common.py
+++ b/src/cloup/constraints/common.py
@@ -2,7 +2,8 @@
 Useful functions used to implement constraints and predicates.
 """
 
-from typing import Any, Iterable, Sequence
+from typing import Any
+from collections.abc import Iterable, Sequence
 
 from click import Argument, Context, Option, Parameter
 

--- a/src/cloup/constraints/conditions.py
+++ b/src/cloup/constraints/conditions.py
@@ -38,7 +38,7 @@ class Predicate(abc.ABC):
 
     def negated_description(self, ctx: click.Context) -> str:
         """Succinct description of the negation of this predicate (alias: `neg_desc`)."""
-        return "NOT({})".format(self.description(ctx))
+        return f"NOT({self.description(ctx)})"
 
     def desc(self, ctx: click.Context) -> str:
         """Short alias for :meth:`description`."""
@@ -95,7 +95,7 @@ class Not(Predicate, Generic[P]):
         return self.predicate
 
     def __repr__(self) -> str:
-        return "Not({!r})".format(self.predicate)
+        return f"Not({self.predicate!r})"
 
 
 class _Operator(Predicate, metaclass=abc.ABCMeta):
@@ -110,9 +110,7 @@ class _Operator(Predicate, metaclass=abc.ABCMeta):
 
     def description(self, ctx: click.Context) -> str:
         return self.DESC_SEP.join(
-            "({})".format(p.description(ctx))
-            if isinstance(p, _Operator)
-            else p.description(ctx)
+            f"({p.description(ctx)})" if isinstance(p, _Operator) else p.description(ctx)
             for p in self.predicates
         )
 
@@ -127,9 +125,7 @@ class _And(_Operator):
 
     def negated_description(self, ctx: click.Context) -> str:
         return " or ".join(
-            "({})".format(p.neg_desc(ctx))
-            if isinstance(p, _Operator)
-            else p.neg_desc(ctx)
+            f"({p.neg_desc(ctx)})" if isinstance(p, _Operator) else p.neg_desc(ctx)
             for p in self.predicates
         )
 
@@ -149,9 +145,7 @@ class _Or(_Operator):
 
     def negated_description(self, ctx: click.Context) -> str:
         return " and ".join(
-            "({})".format(p.neg_desc(ctx))
-            if isinstance(p, _Operator)
-            else p.neg_desc(ctx)
+            f"({p.neg_desc(ctx)})" if isinstance(p, _Operator) else p.neg_desc(ctx)
             for p in self.predicates
         )
 
@@ -171,10 +165,10 @@ class IsSet(Predicate):
         self.param_name = param_name
 
     def description(self, ctx: click.Context) -> str:
-        return "{} is set".format(param_label_by_name(ctx, self.param_name))
+        return f"{param_label_by_name(ctx, self.param_name)} is set"
 
     def negated_description(self, ctx: click.Context) -> str:
-        return "{} is not set".format(param_label_by_name(ctx, self.param_name))
+        return f"{param_label_by_name(ctx, self.param_name)} is not set"
 
     def __call__(self, ctx: click.Context) -> bool:
         command = ensure_constraints_support(ctx.command)

--- a/src/cloup/constraints/conditions.py
+++ b/src/cloup/constraints/conditions.py
@@ -7,7 +7,7 @@ is not (at the moment) enforced.
 """
 
 import abc
-from typing import Any, Dict, Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
 import click
 
@@ -67,7 +67,7 @@ class Predicate(abc.ABC):
     def __repr__(self) -> str:
         return make_repr(self, *self._public_fields().values())
 
-    def _public_fields(self) -> Dict[str, Any]:
+    def _public_fields(self) -> dict[str, Any]:
         return {k: v for k, v in vars(self).items() if not k.startswith("_")}
 
     def __eq__(self, other: object) -> bool:

--- a/src/cloup/constraints/conditions.py
+++ b/src/cloup/constraints/conditions.py
@@ -38,7 +38,7 @@ class Predicate(abc.ABC):
 
     def negated_description(self, ctx: click.Context) -> str:
         """Succinct description of the negation of this predicate (alias: `neg_desc`)."""
-        return "NOT(%s)" % self.description(ctx)
+        return "NOT({})".format(self.description(ctx))
 
     def desc(self, ctx: click.Context) -> str:
         """Short alias for :meth:`description`."""
@@ -95,7 +95,7 @@ class Not(Predicate, Generic[P]):
         return self.predicate
 
     def __repr__(self) -> str:
-        return "Not(%r)" % self.predicate
+        return "Not({!r})".format(self.predicate)
 
 
 class _Operator(Predicate, metaclass=abc.ABCMeta):
@@ -110,7 +110,7 @@ class _Operator(Predicate, metaclass=abc.ABCMeta):
 
     def description(self, ctx: click.Context) -> str:
         return self.DESC_SEP.join(
-            "(%s)" % p.description(ctx)
+            "({})".format(p.description(ctx))
             if isinstance(p, _Operator)
             else p.description(ctx)
             for p in self.predicates
@@ -127,7 +127,9 @@ class _And(_Operator):
 
     def negated_description(self, ctx: click.Context) -> str:
         return " or ".join(
-            "(%s)" % p.neg_desc(ctx) if isinstance(p, _Operator) else p.neg_desc(ctx)
+            "({})".format(p.neg_desc(ctx))
+            if isinstance(p, _Operator)
+            else p.neg_desc(ctx)
             for p in self.predicates
         )
 
@@ -147,7 +149,9 @@ class _Or(_Operator):
 
     def negated_description(self, ctx: click.Context) -> str:
         return " and ".join(
-            "(%s)" % p.neg_desc(ctx) if isinstance(p, _Operator) else p.neg_desc(ctx)
+            "({})".format(p.neg_desc(ctx))
+            if isinstance(p, _Operator)
+            else p.neg_desc(ctx)
             for p in self.predicates
         )
 
@@ -167,10 +171,10 @@ class IsSet(Predicate):
         self.param_name = param_name
 
     def description(self, ctx: click.Context) -> str:
-        return "%s is set" % param_label_by_name(ctx, self.param_name)
+        return "{} is set".format(param_label_by_name(ctx, self.param_name))
 
     def negated_description(self, ctx: click.Context) -> str:
-        return "%s is not set" % param_label_by_name(ctx, self.param_name)
+        return "{} is not set".format(param_label_by_name(ctx, self.param_name))
 
     def __call__(self, ctx: click.Context) -> bool:
         command = ensure_constraints_support(ctx.command)

--- a/src/cloup/constraints/exceptions.py
+++ b/src/cloup/constraints/exceptions.py
@@ -11,10 +11,7 @@ if TYPE_CHECKING:
 
 
 def default_constraint_error(params: Iterable[Parameter], desc: str) -> str:
-    return "the following constraint on parameters [{}] was not satisfied: {}".format(
-        join_param_labels(params),
-        desc,
-    )
+    return f"the following constraint on parameters [{join_param_labels(params)}] was not satisfied: {desc}"
 
 
 class ConstraintViolated(click.UsageError):

--- a/src/cloup/constraints/exceptions.py
+++ b/src/cloup/constraints/exceptions.py
@@ -1,4 +1,5 @@
-from typing import Iterable, Sequence, TYPE_CHECKING
+from typing import TYPE_CHECKING
+from collections.abc import Iterable, Sequence
 
 import click
 from click import Context, Parameter

--- a/src/cloup/constraints/exceptions.py
+++ b/src/cloup/constraints/exceptions.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 
 def default_constraint_error(params: Iterable[Parameter], desc: str) -> str:
-    return "the following constraint on parameters [%s] was not satisfied: %s" % (
+    return "the following constraint on parameters [{}] was not satisfied: {}".format(
         join_param_labels(params),
         desc,
     )

--- a/src/cloup/formatting/_formatter.py
+++ b/src/cloup/formatting/_formatter.py
@@ -6,13 +6,11 @@ from itertools import chain
 from typing import (
     Any,
     Callable,
-    Dict,
     Iterable,
     Iterator,
     Optional,
     Sequence,
     TYPE_CHECKING,
-    Tuple,
     Union,
 )
 
@@ -34,7 +32,7 @@ from cloup._util import (
 from ..typing import MISSING, Possibly
 from cloup.styling import HelpTheme, IStyle
 
-Definition = Tuple[str, Union[str, Callable[[int], str]]]
+Definition = tuple[str, Union[str, Callable[[int], str]]]
 
 
 def _format_deprecation_label(deprecated: Union[bool, str]) -> str:
@@ -171,7 +169,7 @@ class HelpFormatter(click.HelpFormatter):
         col_spacing: Possibly[int] = MISSING,
         row_sep: Possibly[Union[None, str, "SepGenerator", "RowSepPolicy"]] = MISSING,
         theme: Possibly[HelpTheme] = MISSING,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """A utility method for creating a ``formatter_settings`` dictionary to
         pass as context settings or command attribute. This method exists for
         one only reason: it enables auto-complete for formatter options, thus
@@ -370,7 +368,7 @@ class HelpFormatter(click.HelpFormatter):
         row_sep = self._get_row_sep_for(text_rows, (col1_width, col2_width), col_spacing)
         col1_styler, col2_styler = self.theme.col1, self.theme.col2
 
-        def write_row(row: Tuple[str, str]) -> None:
+        def write_row(row: tuple[str, str]) -> None:
             first, second = row
             self.write(indentation, col1_styler(first))
             if not second:
@@ -432,7 +430,7 @@ class HelpFormatter(click.HelpFormatter):
         )
 
 
-def iter_defs(rows: Iterable[Definition], col2_width: int) -> Iterator[Tuple[str, str]]:
+def iter_defs(rows: Iterable[Definition], col2_width: int) -> Iterator[tuple[str, str]]:
     for row in rows:
         if len(row) == 1:
             yield row[0], ""

--- a/src/cloup/formatting/_formatter.py
+++ b/src/cloup/formatting/_formatter.py
@@ -5,7 +5,6 @@ import textwrap
 from itertools import chain
 from typing import (
     Any,
-    Optional,
     TYPE_CHECKING,
     Union,
 )
@@ -50,10 +49,10 @@ class HelpSection:
     """Rows with 2 columns each. The 2nd element of each row can also be a function
     taking an integer (the available width for the 2nd column) and returning a string."""
 
-    help: Optional[str] = None
+    help: str | None = None
     """(Optional) long description of the section."""
 
-    constraint: Optional[str] = None
+    constraint: str | None = None
     """(Optional) option group constraint description."""
 
 
@@ -119,8 +118,8 @@ class HelpFormatter(click.HelpFormatter):
     def __init__(
         self,
         indent_increment: int = 2,
-        width: Optional[int] = None,
-        max_width: Optional[int] = None,
+        width: int | None = None,
+        max_width: int | None = None,
         col1_max_width: int = 30,
         col2_min_width: int = 35,
         col_spacing: int = 2,
@@ -158,8 +157,8 @@ class HelpFormatter(click.HelpFormatter):
     @staticmethod
     def settings(
         *,
-        width: Possibly[Optional[int]] = MISSING,
-        max_width: Possibly[Optional[int]] = MISSING,
+        width: Possibly[int | None] = MISSING,
+        max_width: Possibly[int | None] = MISSING,
         indent_increment: Possibly[int] = MISSING,
         col1_max_width: Possibly[int] = MISSING,
         col2_min_width: Possibly[int] = MISSING,
@@ -183,9 +182,7 @@ class HelpFormatter(click.HelpFormatter):
     def write(self, string: str = "", *strings: str) -> None:
         self.buffer += (string, *strings)
 
-    def write_usage(
-        self, prog: str, args: str = "", prefix: Optional[str] = None
-    ) -> None:
+    def write_usage(self, prog: str, args: str = "", prefix: str | None = None) -> None:
         prefix = "Usage:" if prefix is None else prefix
         prefix = self.theme.heading(prefix) + " "
         prog = self.theme.invoked_command(prog)
@@ -231,7 +228,7 @@ class HelpFormatter(click.HelpFormatter):
         for s in sections:
             self.write_section(s, col1_width=col1_width)
 
-    def write_section(self, s: HelpSection, col1_width: Optional[int] = None) -> None:
+    def write_section(self, s: HelpSection, col1_width: int | None = None) -> None:
         theme = self.theme
         self.write("\n")
         self.write_heading(s.heading, newline=not s.constraint)
@@ -271,9 +268,9 @@ class HelpFormatter(click.HelpFormatter):
     def write_dl(
         self,
         rows: Iterable[Definition],
-        col_max: Optional[int] = None,  # default changed to None wrt parent class
-        col_spacing: Optional[int] = None,  # default changed to None wrt parent class
-        col1_width: Optional[int] = None,
+        col_max: int | None = None,  # default changed to None wrt parent class
+        col_spacing: int | None = None,  # default changed to None wrt parent class
+        col1_width: int | None = None,
     ) -> None:
         """Write a definition list into the buffer. This is how options
         and commands are usually formatted.
@@ -329,7 +326,7 @@ class HelpFormatter(click.HelpFormatter):
         text_rows: Sequence[Sequence[str]],
         col_widths: Sequence[int],
         col_spacing: int,
-    ) -> Optional[str]:
+    ) -> str | None:
         if self.row_sep is None or isinstance(self.row_sep, str):
             return self.row_sep
 

--- a/src/cloup/formatting/_formatter.py
+++ b/src/cloup/formatting/_formatter.py
@@ -29,10 +29,10 @@ from cloup._util import (
 from ..typing import MISSING, Possibly
 from cloup.styling import HelpTheme, IStyle
 
-Definition = tuple[str, Union[str, Callable[[int], str]]]
+Definition = tuple[str, str | Callable[[int], str]]
 
 
-def _format_deprecation_label(deprecated: Union[bool, str]) -> str:
+def _format_deprecation_label(deprecated: bool | str) -> str:
     """Return the parenthesized deprecation label shown in help text."""
     if isinstance(deprecated, str):
         return f"(DEPRECATED: {deprecated})"

--- a/src/cloup/formatting/_formatter.py
+++ b/src/cloup/formatting/_formatter.py
@@ -5,14 +5,11 @@ import textwrap
 from itertools import chain
 from typing import (
     Any,
-    Callable,
-    Iterable,
-    Iterator,
     Optional,
-    Sequence,
     TYPE_CHECKING,
     Union,
 )
+from collections.abc import Callable, Iterable, Iterator, Sequence
 
 from cloup.formatting._util import unstyled_len
 

--- a/src/cloup/formatting/sep.py
+++ b/src/cloup/formatting/sep.py
@@ -91,7 +91,7 @@ class RowSepIf(RowSepPolicy):
         The empty string corresponds to an empty line separator.
     """
 
-    def __init__(self, condition: RowSepCondition, sep: Union[str, SepGenerator] = ""):
+    def __init__(self, condition: RowSepCondition, sep: str | SepGenerator = ""):
         if isinstance(sep, str) and sep.endswith("\n"):
             raise ValueError(
                 "sep must not end with '\\n'. The formatter writes  a '\\n' after it; "
@@ -135,7 +135,7 @@ def count_multiline_rows(rows: Sequence[Sequence[str]], col_widths: Sequence[int
 
 
 def multiline_rows_are_at_least(
-    count_or_percentage: Union[int, float],
+    count_or_percentage: int | float,
 ) -> RowSepCondition:
     """
     Return a ``RowSepStrategy`` that returns a row separator between all rows

--- a/src/cloup/formatting/sep.py
+++ b/src/cloup/formatting/sep.py
@@ -8,7 +8,8 @@ help sections.
 
 import abc
 from itertools import zip_longest
-from typing import Optional, Protocol, Sequence, Union
+from typing import Optional, Protocol, Union
+from collections.abc import Sequence
 
 SepType = Union[str, "SepGenerator"]
 

--- a/src/cloup/formatting/sep.py
+++ b/src/cloup/formatting/sep.py
@@ -8,7 +8,7 @@ help sections.
 
 import abc
 from itertools import zip_longest
-from typing import Optional, Protocol, Union
+from typing import Protocol, Union
 from collections.abc import Sequence
 
 SepType = Union[str, "SepGenerator"]
@@ -49,7 +49,7 @@ class RowSepPolicy(metaclass=abc.ABCMeta):
         rows: Sequence[Sequence[str]],
         col_widths: Sequence[int],
         col_spacing: int,
-    ) -> Optional[str]:
+    ) -> str | None:
         """Decide which row separator to use (eventually none) in the given
         definition list."""
 
@@ -102,7 +102,7 @@ class RowSepIf(RowSepPolicy):
 
     def __call__(
         self, rows: Sequence[Sequence[str]], col_widths: Sequence[int], col_spacing: int
-    ) -> Optional[str]:
+    ) -> str | None:
         if self.condition(rows, col_widths, col_spacing):
             if callable(self.sep):
                 total_width = get_total_width(col_widths, col_spacing)

--- a/src/cloup/styling.py
+++ b/src/cloup/styling.py
@@ -7,7 +7,8 @@ import dataclasses
 import dataclasses as dc
 import sys
 from dataclasses import dataclass
-from typing import Callable, Optional, Union
+from typing import Optional, Union
+from collections.abc import Callable
 
 import click
 

--- a/src/cloup/styling.py
+++ b/src/cloup/styling.py
@@ -7,7 +7,7 @@ import dataclasses
 import dataclasses as dc
 import sys
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Optional
 from collections.abc import Callable
 
 import click
@@ -174,8 +174,8 @@ class Style:
     .. versionadded:: 0.8.0
     """
 
-    fg: Union[int, tuple[int, int, int], str, None] = None
-    bg: Union[int, tuple[int, int, int], str, None] = None
+    fg: int | tuple[int, int, int] | str | None = None
+    bg: int | tuple[int, int, int] | str | None = None
     bold: Optional[bool] = None
     dim: Optional[bool] = None
     underline: Optional[bool] = None

--- a/src/cloup/styling.py
+++ b/src/cloup/styling.py
@@ -7,7 +7,6 @@ import dataclasses
 import dataclasses as dc
 import sys
 from dataclasses import dataclass
-from typing import Optional
 from collections.abc import Callable
 
 import click
@@ -81,7 +80,7 @@ class HelpTheme:
     alias: IStyle = identity
     """Style of subcommand aliases in a definition lists."""
 
-    alias_secondary: Optional[IStyle] = None
+    alias_secondary: IStyle | None = None
     """Style of separator and eventual parenthesis/brackets in subcommand alias lists.
     If not provided, the ``alias`` style will be used."""
 
@@ -90,16 +89,16 @@ class HelpTheme:
 
     def with_(
         self,
-        invoked_command: Optional[IStyle] = None,
-        command_help: Optional[IStyle] = None,
-        heading: Optional[IStyle] = None,
-        constraint: Optional[IStyle] = None,
-        section_help: Optional[IStyle] = None,
-        col1: Optional[IStyle] = None,
-        col2: Optional[IStyle] = None,
-        alias: Optional[IStyle] = None,
-        alias_secondary: Possibly[Optional[IStyle]] = MISSING,
-        epilog: Optional[IStyle] = None,
+        invoked_command: IStyle | None = None,
+        command_help: IStyle | None = None,
+        heading: IStyle | None = None,
+        constraint: IStyle | None = None,
+        section_help: IStyle | None = None,
+        col1: IStyle | None = None,
+        col2: IStyle | None = None,
+        alias: IStyle | None = None,
+        alias_secondary: Possibly[IStyle | None] = MISSING,
+        epilog: IStyle | None = None,
         **kwargs: object,
     ) -> Self:
         """Return a theme of the same type with the supplied fields replaced.
@@ -176,15 +175,15 @@ class Style:
 
     fg: int | tuple[int, int, int] | str | None = None
     bg: int | tuple[int, int, int] | str | None = None
-    bold: Optional[bool] = None
-    dim: Optional[bool] = None
-    underline: Optional[bool] = None
-    overline: Optional[bool] = None
-    italic: Optional[bool] = None
-    blink: Optional[bool] = None
-    reverse: Optional[bool] = None
-    strikethrough: Optional[bool] = None
-    text_transform: Optional[IStyle] = None
+    bold: bool | None = None
+    dim: bool | None = None
+    underline: bool | None = None
+    overline: bool | None = None
+    italic: bool | None = None
+    blink: bool | None = None
+    reverse: bool | None = None
+    strikethrough: bool | None = None
+    text_transform: IStyle | None = None
 
     def __call__(self, text: str) -> str:
         if self.text_transform:

--- a/src/cloup/types.py
+++ b/src/cloup/types.py
@@ -3,14 +3,14 @@ Parameter types and "shortcuts" for creating commonly used types.
 """
 
 import pathlib
-from typing import Type, Any
+from typing import Any
 
 import click
 
 
 def path(
     *,
-    path_type: Type[Any] = pathlib.Path,
+    path_type: type[Any] = pathlib.Path,
     exists: bool = False,
     file_okay: bool = True,
     dir_okay: bool = True,
@@ -26,7 +26,7 @@ def path(
 
 def dir_path(
     *,
-    path_type: Type[Any] = pathlib.Path,
+    path_type: type[Any] = pathlib.Path,
     exists: bool = False,
     readable: bool = True,
     writable: bool = False,
@@ -41,7 +41,7 @@ def dir_path(
 
 def file_path(
     *,
-    path_type: Type[Any] = pathlib.Path,
+    path_type: type[Any] = pathlib.Path,
     exists: bool = False,
     readable: bool = True,
     writable: bool = False,

--- a/src/cloup/typing.py
+++ b/src/cloup/typing.py
@@ -1,7 +1,7 @@
 __all__ = ["AnyCallable", "MISSING", "Possibly", "Decorator", "F"]
 
 from enum import Enum
-from typing import Any, TypeVar, Union
+from typing import Any, TypeAlias, TypeVar
 from collections.abc import Callable
 
 
@@ -17,7 +17,7 @@ Useful when None can't be used to play the role because it represents a valid
 non-null value."""
 
 _T = TypeVar("_T")
-Possibly = Union[_Missing, _T]
+Possibly: TypeAlias = _Missing | _T
 """Possibly[T] is like Optional[T] but uses MISSING for missing values."""
 
 AnyCallable = Callable[..., Any]

--- a/src/cloup/typing.py
+++ b/src/cloup/typing.py
@@ -1,7 +1,8 @@
 __all__ = ["AnyCallable", "MISSING", "Possibly", "Decorator", "F"]
 
 from enum import Enum
-from typing import Any, Callable, TypeVar, Union
+from typing import Any, TypeVar, Union
+from collections.abc import Callable
 
 
 # PEP-blessed solution for defining a Singleton type:

--- a/tests/constraints/test_conditional_constraints.py
+++ b/tests/constraints/test_conditional_constraints.py
@@ -1,5 +1,4 @@
 from itertools import combinations
-from typing import Optional
 from unittest.mock import Mock
 
 import pytest
@@ -25,7 +24,7 @@ class FakePredicate(Predicate):
         self,
         value: bool = True,
         desc: str = "description",
-        neg_desc: Optional[str] = None,
+        neg_desc: str | None = None,
     ):
         self.value = value
         self._desc = desc

--- a/tests/constraints/test_constraints.py
+++ b/tests/constraints/test_constraints.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Sequence
+from collections.abc import Sequence
 from unittest import mock
 from unittest.mock import Mock
 

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import click
 import pytest
 
@@ -188,7 +186,7 @@ def test_alias_are_correctly_styled(runner):
     red = Style(fg=Color.red)
     green = Style(fg=Color.green)
 
-    def fmt(alias: IStyle = identity, alias_secondary: Optional[IStyle] = None):
+    def fmt(alias: IStyle = identity, alias_secondary: IStyle | None = None):
         theme = HelpTheme(alias=alias, alias_secondary=alias_secondary)
         return Group.format_subcommand_aliases(["i", "add"], theme)
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -4,7 +4,6 @@ Tip: in your editor, set a ruler at 80 characters.
 
 import inspect
 from textwrap import dedent
-from typing import Optional
 
 import click
 import pytest
@@ -146,7 +145,7 @@ def test_fixed_row_sep(row_sep):
     ),
     pytest.param(RowSepIf(multiline_rows_are_at_least(4)), None, id="no_sep"),
 )
-def test_conditional_row_sep(policy: RowSepPolicy, expected_sep: Optional[str]):
+def test_conditional_row_sep(policy: RowSepPolicy, expected_sep: str | None):
     formatter = HelpFormatter(
         width=80,
         col1_max_width=30,

--- a/tests/test_styling.py
+++ b/tests/test_styling.py
@@ -1,6 +1,7 @@
 import inspect
 from dataclasses import dataclass
-from typing import Callable, Optional
+from typing import Optional
+from collections.abc import Callable
 
 import click
 import pytest

--- a/tests/test_styling.py
+++ b/tests/test_styling.py
@@ -1,6 +1,5 @@
 import inspect
 from dataclasses import dataclass
-from typing import Optional
 from collections.abc import Callable
 
 import click
@@ -14,7 +13,7 @@ from cloup.styling import Color, HelpTheme, IStyle, Style
 @dataclass(frozen=True)
 class CustomTheme(HelpTheme):
     metavar: IStyle = identity
-    label: Optional[str] = "default"
+    label: str | None = "default"
 
 
 @dataclass(frozen=True)

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -2,7 +2,7 @@
 
 # mypy: warn-unused-ignores
 
-from typing import TYPE_CHECKING, Any, Optional, get_type_hints
+from typing import TYPE_CHECKING, Any, get_type_hints
 
 import click
 import pytest
@@ -114,7 +114,7 @@ def test_parameter_decorators_preserve_callback_types() -> None:
 def test_option_group_attribute_type() -> None:
     group = cloup.OptionGroup("Options")
     option = cloup.Option(["--value"], group=group)
-    assert_type(option.group, Optional[cloup.OptionGroup])
+    assert_type(option.group, cloup.OptionGroup | None)
     assert option.group is group
 
 
@@ -133,7 +133,7 @@ def test_context_types() -> None:
         assert_type(cloup.get_current_context(), cloup.Context)
         assert_type(cloup.get_current_context(False), cloup.Context)
         assert_type(cloup.get_current_context(silent=False), cloup.Context)
-        assert_type(cloup.get_current_context(True), Optional[cloup.Context])
+        assert_type(cloup.get_current_context(True), cloup.Context | None)
         assert cloup.get_current_context(False) is ctx
     assert cloup.get_current_context(silent=True) is None
     with pytest.raises(RuntimeError):
@@ -156,7 +156,7 @@ def test_pass_context_preserves_signature() -> None:
 if TYPE_CHECKING:
 
     def check_rejected_calls(silent: bool) -> None:
-        assert_type(cloup.get_current_context(silent), Optional[cloup.Context])
+        assert_type(cloup.get_current_context(silent), cloup.Context | None)
         parent = cloup.Group("parent")
         parent.group(unknown=True)  # type: ignore[call-overload]
         parent.group(cls=None, unknown=True)  # type: ignore[call-overload]

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from typing import Iterable, List
+from typing import Iterable
 from unittest.mock import Mock
 
 import click
@@ -59,7 +59,7 @@ def make_fake_context(
     )
 
 
-def make_options(names: Iterable[str], **common_kwargs) -> List[click.Option]:
+def make_options(names: Iterable[str], **common_kwargs) -> list[click.Option]:
     return [click.Option([f"--{name}"], **common_kwargs) for name in names]
 
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from typing import Iterable
+from collections.abc import Iterable
 from unittest.mock import Mock
 
 import click


### PR DESCRIPTION
Enable pyupgrade Ruff rules:

- UP006 collection annotations
- UP007 unions
- UP031 percent formatting
- UP032 f-strings
- UP035 deprecated imports
- UP037 quoted annotations
- UP045 optionals

A full --select UP audit now reports no findings.

Closes #226.