### PR TITLE
Make command decorators interchangeable with Click's

### DIFF
--- a/src/cloup/_commands.py
+++ b/src/cloup/_commands.py
@@ -22,6 +22,9 @@ Like Click, Cloup accepts ``cls`` positionally. That form needs an overload of
 its own, and it repeats the keyword arguments of the keyword-``cls`` overload so
 that they keep being type-checked in both call styles.
 
+A last overload covers the parenthesis-less form (``@command`` instead of
+``@command()``), in which the decorated callback takes the place of ``name``.
+
 """
 
 import inspect
@@ -289,10 +292,18 @@ class Group(SectionMixin, Command, click.Group):
                 + secondary_style(")")
             )
 
-    # Click also supports bare decorators, which Cloup rejects, so this override
-    # is intentionally narrower than the one it replaces.
-    @overload  # type: ignore[override]
+    # Click types these methods as ``(*args: Any, **kwargs: Any)``, i.e. as an
+    # unspecified signature, so any signature naming its arguments is formally
+    # narrower. MyPy reads an unspecified supertype signature as "anything goes"
+    # and accepts it; Pyrefly has no such rule, hence the suppression. Satisfying
+    # Pyrefly would require a trailing ``(*args: Any, **kwargs: Any)`` overload,
+    # which would swallow every keyword argument error these overloads exist to
+    # catch.
+    @overload
     # pyrefly: ignore[bad-override]
+    def command(self, name: AnyCallable, /) -> click.Command: ...
+
+    @overload
     def command(  # Why overloading? Refer to module docstring.
         self,
         name: str | None = None,
@@ -360,13 +371,13 @@ class Group(SectionMixin, Command, click.Group):
     @override
     def command(
         self,
-        name: str | None = None,
+        name: str | AnyCallable | None = None,
         cls: type[C] | None = None,
         *,
         aliases: Iterable[str] | None = None,
         section: Section | None = None,
         **kwargs: Any,
-    ) -> Callable[[AnyCallable], click.Command | C]:
+    ) -> click.Command | Callable[[AnyCallable], click.Command | C]:
         """Return a decorator that creates a new subcommand of this ``Group``
         using the decorated function as callback.
 
@@ -376,11 +387,13 @@ class Group(SectionMixin, Command, click.Group):
             if provided, put the subcommand in this section.
 
         .. versionchanged:: 4.0.0
-            ``cls`` can be passed positionally, like in Click.
+            the decorator can be applied without parentheses and ``cls`` can be
+            passed positionally, like in Click.
 
         .. versionchanged:: 0.10.0
             all arguments but ``name`` are now keyword-only.
         """
+        func, name = _resolve_decorator_first_arg(name)
         make_command = command(
             name=name,
             cls=(self.command_class if cls is None else cls),
@@ -393,11 +406,14 @@ class Group(SectionMixin, Command, click.Group):
             self.add_command(cmd, section=section)
             return cmd
 
-        return decorator
+        return decorator(func) if func is not None else decorator
 
-    # As with command(), Cloup intentionally has a narrower decorator API.
-    @overload  # type: ignore[override]
+    # Narrower than Click's for the same reason as command(); see the note there.
+    @overload
     # pyrefly: ignore[bad-override]
+    def group(self, name: AnyCallable, /) -> click.Group: ...
+
+    @overload
     def group(  # Why overloading? Refer to module docstring.
         self,
         name: str | None = None,
@@ -477,13 +493,13 @@ class Group(SectionMixin, Command, click.Group):
     @override
     def group(
         self,
-        name: str | None = None,
+        name: str | AnyCallable | None = None,
         cls: type[G] | None = None,
         *,
         aliases: Iterable[str] | None = None,
         section: Section | None = None,
         **kwargs: Any,
-    ) -> Callable[[AnyCallable], click.Group | G]:
+    ) -> click.Group | Callable[[AnyCallable], click.Group | G]:
         """Return a decorator that creates a new subcommand of this ``Group``
         using the decorated function as callback.
 
@@ -493,11 +509,13 @@ class Group(SectionMixin, Command, click.Group):
             if provided, put the subcommand in this section.
 
         .. versionchanged:: 4.0.0
-            ``cls`` can be passed positionally, like in Click.
+            the decorator can be applied without parentheses and ``cls`` can be
+            passed positionally, like in Click.
 
         .. versionchanged:: 0.10.0
             all arguments but ``name`` are now keyword-only.
         """
+        func, name = _resolve_decorator_first_arg(name)
         make_group = group(
             name=name, cls=cls or self._default_group_class(), aliases=aliases, **kwargs
         )
@@ -507,7 +525,7 @@ class Group(SectionMixin, Command, click.Group):
             self.add_command(cmd, section=section)
             return cmd
 
-        return decorator
+        return decorator(func) if func is not None else decorator
 
     @classmethod
     def _default_group_class(cls) -> type[click.Group] | None:
@@ -520,6 +538,10 @@ class Group(SectionMixin, Command, click.Group):
 
 
 # Why overloading? Refer to module docstring.
+@overload  # In this overload: bare decorator, i.e. "@command" without parentheses
+def command(name: AnyCallable, /) -> Command: ...
+
+
 @overload  # In this overload: "cls: None = None"
 def command(
     name: str | None = None,
@@ -584,12 +606,12 @@ def command(  # In this overload: "cls" passed positionally, as Click allows
 
 # noinspection PyIncorrectDocstring
 def command(
-    name: str | None = None,
+    name: str | AnyCallable | None = None,
     cls: type[C] | None = None,
     *,
     aliases: Iterable[str] | None = None,
     **kwargs: Any,
-) -> Callable[[AnyCallable], Command | C]:
+) -> Command | Callable[[AnyCallable], Command | C]:
     """
     Return a decorator that creates a new command using the decorated function
     as callback.
@@ -602,7 +624,8 @@ def command(
     - this function has detailed type hints and uses generics for the ``cls``
       argument and return type.
 
-    Like in Click, ``cls`` can be passed positionally.
+    Like in Click, the decorator can be applied with or without parentheses and
+    ``cls`` can be passed positionally.
 
     Note that the following arguments are about Cloup-specific features and are
     not supported by all ``click.Command``, so if you provide a custom ``cls``
@@ -613,7 +636,8 @@ def command(
     - ``show_constraints`` (``cls`` needs to inherit ``ConstraintMixin``).
 
     .. versionchanged:: 4.0.0
-        ``cls`` can be passed positionally, like in Click.
+        the decorator can be applied without parentheses and ``cls`` can be passed
+        positionally, like in Click.
 
     .. versionchanged:: 0.10.0
         this function is now generic: the return type depends on what you provide
@@ -674,12 +698,7 @@ def command(
     :param kwargs:
         any other argument accepted by the instantiated command class (``cls``).
     """
-    if callable(name):
-        raise Exception(
-            f"you forgot parenthesis in the command decorator for "
-            f"`{getattr(name, '__name__', name)}`. "
-            f"While parenthesis are optional in Click >= 8.1, they are required in Cloup."
-        )
+    func, name = _resolve_decorator_first_arg(name)
 
     def decorator(f: AnyCallable) -> Command | C:
         if hasattr(f, "__cloup_constraints__"):
@@ -701,10 +720,15 @@ def command(
         except TypeError as error:
             raise _process_unexpected_kwarg_error(error, _ARGS_INFO, cmd_cls)
 
-    return decorator
+    return decorator(func) if func is not None else decorator
 
 
-@overload  # Why overloading? Refer to module docstring.
+# Why overloading? Refer to module docstring.
+@overload  # In this overload: bare decorator, i.e. "@group" without parentheses
+def group(name: AnyCallable, /) -> Group: ...
+
+
+@overload
 def group(
     name: str | None = None,
     cls: None = None,
@@ -779,16 +803,18 @@ def group(  # In this overload: "cls" passed positionally, as Click allows
 
 
 def group(
-    name: str | None = None, cls: type[G] | None = None, **kwargs: Any
-) -> Callable[[AnyCallable], click.Group]:
+    name: str | AnyCallable | None = None, cls: type[G] | None = None, **kwargs: Any
+) -> click.Group | Callable[[AnyCallable], click.Group]:
     """
     Return a decorator that instantiates a ``Group`` (or a subclass of it)
     using the decorated function as callback.
 
-    As with :func:`command`, ``cls`` can be passed positionally.
+    As with :func:`command`, the decorator can be applied with or without
+    parentheses and ``cls`` can be passed positionally.
 
     .. versionchanged:: 4.0.0
-        ``cls`` can be passed positionally, like in Click.
+        the decorator can be applied without parentheses and ``cls`` can be passed
+        positionally, like in Click.
 
     .. versionchanged:: 0.10.0
         the ``cls`` argument can now be any ``click.Group`` (previously had to
@@ -863,8 +889,23 @@ def group(
         raise TypeError(
             "this decorator requires `cls` to be a `click.Group` (or a subclass)"
         )
+    func, name = _resolve_decorator_first_arg(name)
     group_cls: type[click.Group] = Group if cls is None else cls
-    return command(name=name, cls=group_cls, **kwargs)
+    make_group = command(name=name, cls=group_cls, **kwargs)
+    return make_group(func) if func is not None else make_group
+
+
+def _resolve_decorator_first_arg(
+    name: str | AnyCallable | None,
+) -> tuple[AnyCallable | None, str | None]:
+    """Resolve the first argument of a command decorator into ``(func, name)``.
+
+    Click's decorators can be applied without parentheses, in which case the
+    decorated callback takes the place of ``name``. Cloup mirrors that.
+    """
+    if callable(name):
+        return name, None
+    return None, name
 
 
 # Side stuff for better error messages

--- a/src/cloup/_commands.py
+++ b/src/cloup/_commands.py
@@ -18,6 +18,10 @@ The explicit keyword parameters provide IDE completion and show defaults.
 record their default values. The custom-class overloads also allow arbitrary
 extra keywords for subclass constructors.
 
+Like Click, Cloup accepts ``cls`` positionally. That form needs an overload of
+its own, and it repeats the keyword arguments of the keyword-``cls`` overload so
+that they keep being type-checked in both call styles.
+
 """
 
 import inspect
@@ -285,16 +289,16 @@ class Group(SectionMixin, Command, click.Group):
                 + secondary_style(")")
             )
 
-    # Click also supports bare decorators and positional cls; Cloup requires
-    # parentheses and keyword-only cls, so this override is intentionally narrower.
+    # Click also supports bare decorators, which Cloup rejects, so this override
+    # is intentionally narrower than the one it replaces.
     @overload  # type: ignore[override]
     # pyrefly: ignore[bad-override]
     def command(  # Why overloading? Refer to module docstring.
         self,
         name: str | None = None,
+        cls: None = None,  # default to Group.command_class or cloup.Command
         *,
         aliases: Iterable[str] | None = None,
-        cls: None = None,  # default to Group.command_class or cloup.Command
         section: Section | None = None,
         context_settings: dict[str, Any] | None = None,
         formatter_settings: dict[str, Any] | None = None,
@@ -332,13 +336,34 @@ class Group(SectionMixin, Command, click.Group):
         **kwargs: Any,
     ) -> Callable[[AnyCallable], C]: ...
 
+    @overload
+    def command(  # In this overload: "cls" passed positionally, as Click allows
+        self,
+        name: str | None,
+        cls: type[C],
+        *,
+        aliases: Iterable[str] | None = None,
+        section: Section | None = None,
+        context_settings: dict[str, Any] | None = None,
+        help: str | None = None,
+        epilog: str | None = None,
+        short_help: str | None = None,
+        options_metavar: str | None = "[OPTIONS]",
+        add_help_option: bool = True,
+        no_args_is_help: bool = False,
+        hidden: bool = False,
+        deprecated: bool | str = False,
+        params: list[click.Parameter] | None = None,
+        **kwargs: Any,
+    ) -> Callable[[AnyCallable], C]: ...
+
     @override
     def command(
         self,
         name: str | None = None,
+        cls: type[C] | None = None,
         *,
         aliases: Iterable[str] | None = None,
-        cls: type[C] | None = None,
         section: Section | None = None,
         **kwargs: Any,
     ) -> Callable[[AnyCallable], click.Command | C]:
@@ -349,6 +374,9 @@ class Group(SectionMixin, Command, click.Group):
 
         ``section``: ``Optional[Section]``
             if provided, put the subcommand in this section.
+
+        .. versionchanged:: 4.0.0
+            ``cls`` can be passed positionally, like in Click.
 
         .. versionchanged:: 0.10.0
             all arguments but ``name`` are now keyword-only.
@@ -373,9 +401,9 @@ class Group(SectionMixin, Command, click.Group):
     def group(  # Why overloading? Refer to module docstring.
         self,
         name: str | None = None,
+        cls: None = None,  # cls not provided
         *,
         aliases: Iterable[str] | None = None,
-        cls: None = None,  # cls not provided
         section: Section | None = None,
         sections: Iterable[Section] = (),
         align_sections: bool | None = None,
@@ -422,12 +450,36 @@ class Group(SectionMixin, Command, click.Group):
         **kwargs: Any,
     ) -> Callable[[AnyCallable], G]: ...
 
+    @overload
+    def group(  # In this overload: "cls" passed positionally, as Click allows
+        self,
+        name: str | None,
+        cls: type[G],
+        *,
+        aliases: Iterable[str] | None = None,
+        section: Section | None = None,
+        invoke_without_command: bool = False,
+        no_args_is_help: bool = False,
+        context_settings: dict[str, Any] | None = None,
+        help: str | None = None,
+        epilog: str | None = None,
+        short_help: str | None = None,
+        options_metavar: str | None = "[OPTIONS]",
+        subcommand_metavar: str | None = None,
+        add_help_option: bool = True,
+        chain: bool = False,
+        hidden: bool = False,
+        deprecated: bool | str = False,
+        params: list[click.Parameter] | None = None,
+        **kwargs: Any,
+    ) -> Callable[[AnyCallable], G]: ...
+
     @override
     def group(
         self,
         name: str | None = None,
-        *,
         cls: type[G] | None = None,
+        *,
         aliases: Iterable[str] | None = None,
         section: Section | None = None,
         **kwargs: Any,
@@ -439,6 +491,9 @@ class Group(SectionMixin, Command, click.Group):
 
         ``section``: ``Optional[Section]``
             if provided, put the subcommand in this section.
+
+        .. versionchanged:: 4.0.0
+            ``cls`` can be passed positionally, like in Click.
 
         .. versionchanged:: 0.10.0
             all arguments but ``name`` are now keyword-only.
@@ -468,9 +523,9 @@ class Group(SectionMixin, Command, click.Group):
 @overload  # In this overload: "cls: None = None"
 def command(
     name: str | None = None,
+    cls: None = None,
     *,
     aliases: Iterable[str] | None = None,
-    cls: None = None,
     context_settings: dict[str, Any] | None = None,
     formatter_settings: dict[str, Any] | None = None,
     help: str | None = None,
@@ -507,12 +562,32 @@ def command(  # In this overload: "cls: ClickCommand"
 ) -> Callable[[AnyCallable], C]: ...
 
 
+@overload
+def command(  # In this overload: "cls" passed positionally, as Click allows
+    name: str | None,
+    cls: type[C],
+    *,
+    aliases: Iterable[str] | None = None,
+    context_settings: dict[str, Any] | None = None,
+    help: str | None = None,
+    short_help: str | None = None,
+    epilog: str | None = None,
+    options_metavar: str | None = "[OPTIONS]",
+    add_help_option: bool = True,
+    no_args_is_help: bool = False,
+    hidden: bool = False,
+    deprecated: bool | str = False,
+    params: list[click.Parameter] | None = None,
+    **kwargs: Any,
+) -> Callable[[AnyCallable], C]: ...
+
+
 # noinspection PyIncorrectDocstring
 def command(
     name: str | None = None,
+    cls: type[C] | None = None,
     *,
     aliases: Iterable[str] | None = None,
-    cls: type[C] | None = None,
     **kwargs: Any,
 ) -> Callable[[AnyCallable], Command | C]:
     """
@@ -527,6 +602,8 @@ def command(
     - this function has detailed type hints and uses generics for the ``cls``
       argument and return type.
 
+    Like in Click, ``cls`` can be passed positionally.
+
     Note that the following arguments are about Cloup-specific features and are
     not supported by all ``click.Command``, so if you provide a custom ``cls``
     make sure you don't set these:
@@ -534,6 +611,9 @@ def command(
     - ``formatter_settings``
     - ``align_option_groups`` (``cls`` needs to inherit from ``OptionGroupMixin``)
     - ``show_constraints`` (``cls`` needs to inherit ``ConstraintMixin``).
+
+    .. versionchanged:: 4.0.0
+        ``cls`` can be passed positionally, like in Click.
 
     .. versionchanged:: 0.10.0
         this function is now generic: the return type depends on what you provide
@@ -627,8 +707,8 @@ def command(
 @overload  # Why overloading? Refer to module docstring.
 def group(
     name: str | None = None,
-    *,
     cls: None = None,
+    *,
     aliases: Iterable[str] | None = None,
     sections: Iterable[Section] = (),
     align_sections: bool | None = None,
@@ -675,12 +755,40 @@ def group(
 ) -> Callable[[AnyCallable], G]: ...
 
 
+@overload
+def group(  # In this overload: "cls" passed positionally, as Click allows
+    name: str | None,
+    cls: type[G],
+    *,
+    aliases: Iterable[str] | None = None,
+    invoke_without_command: bool = False,
+    no_args_is_help: bool = False,
+    context_settings: dict[str, Any] | None = None,
+    help: str | None = None,
+    short_help: str | None = None,
+    epilog: str | None = None,
+    options_metavar: str | None = "[OPTIONS]",
+    subcommand_metavar: str | None = None,
+    add_help_option: bool = True,
+    chain: bool = False,
+    hidden: bool = False,
+    deprecated: bool | str = False,
+    params: list[click.Parameter] | None = None,
+    **kwargs: Any,
+) -> Callable[[AnyCallable], G]: ...
+
+
 def group(
-    name: str | None = None, *, cls: type[G] | None = None, **kwargs: Any
+    name: str | None = None, cls: type[G] | None = None, **kwargs: Any
 ) -> Callable[[AnyCallable], click.Group]:
     """
     Return a decorator that instantiates a ``Group`` (or a subclass of it)
     using the decorated function as callback.
+
+    As with :func:`command`, ``cls`` can be passed positionally.
+
+    .. versionchanged:: 4.0.0
+        ``cls`` can be passed positionally, like in Click.
 
     .. versionchanged:: 0.10.0
         the ``cls`` argument can now be any ``click.Group`` (previously had to
@@ -751,14 +859,12 @@ def group(
     :param kwargs:
         any other argument accepted by the instantiated command class.
     """
-    if cls is None:
-        return command(name=name, cls=Group, **kwargs)
-    elif issubclass(cls, click.Group):
-        return command(name=name, cls=cls, **kwargs)
-    else:
+    if cls is not None and not issubclass(cls, click.Group):
         raise TypeError(
             "this decorator requires `cls` to be a `click.Group` (or a subclass)"
         )
+    group_cls: type[click.Group] = Group if cls is None else cls
+    return command(name=name, cls=group_cls, **kwargs)
 
 
 # Side stuff for better error messages

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -5,6 +5,7 @@ import pytest
 
 import cloup
 from cloup._util import reindent
+from cloup.constraints import mutually_exclusive
 from tests.util import new_dummy_func
 
 
@@ -244,31 +245,47 @@ def test_group_subcommand_decorators_accept_cls_as_positional_argument():
     assert root.commands == {"sub-cmd": subcommand, "sub-grp": subgroup}
 
 
-@pytest.mark.parametrize("decorator", [cloup.command, cloup.group])
-def test_error_is_raised_when_command_decorators_are_used_without_parenthesis(decorator):
-    with pytest.raises(Exception, match="parenthesis"):
+@pytest.mark.parametrize(
+    "decorator, expected_cls",
+    [(cloup.command, cloup.Command), (cloup.group, cloup.Group)],
+)
+def test_command_decorators_can_be_used_without_parenthesis(decorator, expected_cls):
+    @decorator
+    def cmd_without_parenthesis():
+        pass
 
-        @decorator
-        def cmd():
-            pass
+    assert isinstance(cmd_without_parenthesis, expected_cls)
+    # The callback takes the place of `name`, so the name is derived from it.
+    assert cmd_without_parenthesis.name == "cmd-without-parenthesis"
 
 
-def test_error_is_raised_when_group_subcommand_decorators_are_used_without_parenthesis():
+def test_group_subcommand_decorators_can_be_used_without_parenthesis():
     @cloup.group()
     def root():
         pass
 
-    with pytest.raises(Exception, match="parenthesis"):
+    @root.group
+    def subgroup():
+        pass
 
-        @root.group
-        def subgroup():
-            pass
+    @root.command
+    def subcommand():
+        pass
 
-    with pytest.raises(Exception, match="parenthesis"):
+    assert isinstance(subgroup, cloup.Group)
+    assert isinstance(subcommand, cloup.Command)
+    assert root.commands == {"subgroup": subgroup, "subcommand": subcommand}
 
-        @root.command
-        def subcommand():
-            pass
+
+def test_command_decorators_without_parenthesis_support_constraints():
+    @cloup.command
+    @cloup.option("--one")
+    @cloup.option("--two")
+    @cloup.constraint(mutually_exclusive, ["one", "two"])
+    def cmd(one, two):
+        pass
+
+    assert len(cmd.param_constraints) == 1
 
 
 def test_group_command_class_is_used_to_create_subcommands(runner):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -204,6 +204,46 @@ class TestDidYouMean:
         )
 
 
+@pytest.mark.parametrize(
+    "decorator, cls",
+    [(cloup.command, cloup.Command), (cloup.group, cloup.Group)],
+)
+def test_command_decorators_accept_cls_as_positional_argument(decorator, cls):
+    class CustomClass(cls):
+        pass
+
+    @decorator("cmd", CustomClass)
+    def cmd():
+        pass
+
+    assert isinstance(cmd, CustomClass)
+    assert cmd.name == "cmd"
+
+
+def test_group_subcommand_decorators_accept_cls_as_positional_argument():
+    class CustomCommand(cloup.Command):
+        pass
+
+    class CustomGroup(cloup.Group):
+        pass
+
+    @cloup.group()
+    def root():
+        pass
+
+    @root.command("sub-cmd", CustomCommand)
+    def subcommand():
+        pass
+
+    @root.group("sub-grp", CustomGroup)
+    def subgroup():
+        pass
+
+    assert isinstance(subcommand, CustomCommand)
+    assert isinstance(subgroup, CustomGroup)
+    assert root.commands == {"sub-cmd": subcommand, "sub-grp": subgroup}
+
+
 @pytest.mark.parametrize("decorator", [cloup.command, cloup.group])
 def test_error_is_raised_when_command_decorators_are_used_without_parenthesis(decorator):
     with pytest.raises(Exception, match="parenthesis"):


### PR DESCRIPTION
Starting with v4.0.0, Cloup will make an effort to be interchangeable with Click. This PR aligns Cloup with Click in how you can call command decorators. There are indeed two (undocumented) differences right now:

1. in click, you can use command decorators without parenthesis ("bare decorators"); cloup requires parenthesis even when no args are passed
2. in click, `cls` can be passed as 2nd positional argument; in Cloup, it must be a keyword argument.
